### PR TITLE
Update to reference raw content from main branch instead of fork

### DIFF
--- a/src/pages/references/destination-authoring.md
+++ b/src/pages/references/destination-authoring.md
@@ -1,5 +1,5 @@
 ---
 title: Destination Authoring API
 description: Author a destination in the Experience Platform catalog
-openAPISpec: https://raw.githubusercontent.com/vgiurgiu/experience-platform-apis/PLAT-101319-destination-sdk-to-adobeio/src/swagger-specs/destination-authoring.yaml
+openAPISpec: https://raw.githubusercontent.com/AdobeDocs/experience-platform-apis/main/src/swagger-specs/destination-authoring.yaml
 --- 


### PR DESCRIPTION
As mentioned in the description of https://github.com/AdobeDocs/experience-platform-apis/pull/41 , I am updating `https://raw.githubusercontent.com/vgiurgiu/experience-platform-apis/PLAT-101319-destination-sdk-to-adobeio/src/swagger-specs/destination-authoring.yaml` to `https://raw.githubusercontent.com/AdobeDocs/experience-platform-apis/main/src/swagger-specs/destination-authoring.yaml` in the file `src/pages/references/destination-authoring.md`