### PR TITLE
Adding information about Destination Authoring API to index.md [READY]

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -93,6 +93,12 @@ Manage usage labels for existing datasets within the Data Lake.
 
 <DiscoverBlock slots="link, text"/>
 
+[Destination Authoring API (Destination SDK)](references/destination-authoring.md) 
+
+Author a destination in the Experience Platform catalog.
+
+<DiscoverBlock slots="link, text"/>
+
 [Flow Service API](references/flow-service.md) 
 
 Ingest data from external sources into Experience Platform.


### PR DESCRIPTION
## Description

Adding information about Destination Authoring API, so that it appears on the Experience Platform API reference overview page (https://www.adobe.io/experience-platform-apis/) 
