### PR TITLE
PLAT-101321 - Adding a link to Postman collection from Destination Authoring API / Destination SDK reference

### DIFF
--- a/src/swagger-specs/destination-authoring.yaml
+++ b/src/swagger-specs/destination-authoring.yaml
@@ -8,6 +8,11 @@ info:
         - [Destination SDK overview](http://www.adobe.com/go/destination-sdk-overview-en)
         - [Getting started](http://www.adobe.com/go/destination-sdk-getting-started-en)
 
+    - Visualize API calls with Postman (a free, third-party software):
+        - [Destination Authoring API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Destination%20Authoring%20API.postman_collection.json)
+        - [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)
+        - [Steps for importing environments and collections in Postman](https://learning.postman.com/docs/getting-started/importing-and-exporting-data/)
+
     - API paths:
         - PLATFORM Gateway URL: https://<span>platform.adobe.io
         - Base path for this API: /data/core/activation/authoring


### PR DESCRIPTION
## Description

Adding a link from the API reference docs to the newly generated Postman collection for Destination Authoring API/Destination SDK.