### PR TITLE
Remove synchronousValidation query param from streaming ingestion API

### DIFF
--- a/src/swagger-specs/data-ingestion.yaml
+++ b/src/swagger-specs/data-ingestion.yaml
@@ -78,15 +78,6 @@ paths:
           enum:
             - true
             - false
-        - in: "query"
-          name: "synchronousValidation"
-          required: false
-          deprecated: true
-          type: boolean
-          description: "This query parameter is __deprecated__ and will be removed in a future release. Please use `syncValidation` instead."
-          enum:
-            - true
-            - false
       responses:
         '200':
           description: "The data was successfully ingested."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Removed synchronousValidation query param from streaming ingestion API

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/PLAT-126028 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

synchronousValidation query param is deprecated and is only supported for sending single messages, not multiple messages through the API

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
