### PR TITLE
Hide Destination SDK from dropdown

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -57,10 +57,6 @@ module.exports = {
           title: 'Dataset Service API',
           description: 'Manage usage labels for existing datasets within the Data Lake.',
           path: '/references/dataset-service.md'
-        }, {
-          title: 'Destination Authoring API',
-          description: 'Author a destination in the Experience Platform catalog.',
-          path: '/references/destination-authoring.md'
         }, {          
           title: 'Flow Service API',
           description: 'Ingest data from external sources into Experience Platform.',


### PR DESCRIPTION
testing for https://jira.corp.adobe.com/browse/PLAT-128760 
looking to find out how I can have a page live on the devsite but not appear in the dropdown API selector 