### PR TITLE
Identity Service title correction

### DIFF
--- a/src/swagger-specs/identity-service.yaml
+++ b/src/swagger-specs/identity-service.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  title: Identity Service
+  title: Identity Service API
   version: '1.0'
   description: >-
     Delivering relevant digital experiences requires having a complete understanding of your customer. This is made more difficult when your customer data is fragmented across disparate systems, causing each individual customer to appear to have multiple "identities". Adobe Experience Platform Identity Service provides a RESTful API to help you to gain a better view of your customers and their behavior. By bridging identities across devices and systems, you are better able to deliver impactful, personal digital experiences in real-time.


### PR DESCRIPTION
Minor title correction from "Identity Service" to "Identity Service API" for consistency with other swaggers.