### PR TITLE
Destination Authoring API - Fixes when parsing the reference in editor.swagger.io

### DIFF
--- a/src/swagger-specs/destination-authoring.yaml
+++ b/src/swagger-specs/destination-authoring.yaml
@@ -895,9 +895,6 @@ paths:
           description: "Forbidden. The requester is not authorized to access the resource or a mandatory header might be missing from the request. Verify your request and try again."
         "404":
           description: "Resource not found. Verify that you are using the correct destination configuration ID before trying again."
-      security:
-        - dest_auth:
-            - "read:dest"
   /testing/template/render:
     post:
       tags:
@@ -3183,7 +3180,7 @@ definitions:
         example: 200
         description: The code returned by the destination endpoint in response to the test call made by Experience Platform.        
       headers:
-        type: array
+        type: string
         example: [
                      {
                         "Connection":"keep-alive"


### PR DESCRIPTION
When parsing the file in editor.swagger.io, the errors displayed in red are flagged: 

![Screenshot 2024-03-04 at 16 15 26](https://github.com/AdobeDocs/experience-platform-apis/assets/19704189/7b40c230-f4d2-4ca5-aecc-69ff47f472aa)

This PR fixes the two errors and unblocks work to create Postman collections from the API references.