### PR TITLE
PLAT-183006 ens32110 bugfix [REVIEW]

### DIFF
--- a/src/swagger-specs/privacy-service.yaml
+++ b/src/swagger-specs/privacy-service.yaml
@@ -774,9 +774,6 @@ definitions:
           - 'low'
           - 'normal'
         description: An optional property used by Adobe Analytics that sets the priority for processing requests. Accepted values are `normal` and `low`. If priority is omitted, the default behavior is `normal`.
-      rootJobId:
-        type: string
-        description: You can create child jobs by including this property and setting its value to the `jobId` of the desired parent job.
       region:
         type: string
         description: The region code for the request.

--- a/src/swagger-specs/schema-registry.yaml
+++ b/src/swagger-specs/schema-registry.yaml
@@ -1895,7 +1895,7 @@ definitions:
                   meta:xdmType: object
                   meta:xdmField: xdm:person
           allOf:
-          - "$ref": https://ns.adobe.com/xdm/common/extensible#/definitions/@context
+          - "$ref": https://ns.adobe.com/xdm/common/extensible#/definitions/%40context
             type: object
             meta:xdmType: object
           - "$ref": "#/definitions/profile-person-details"
@@ -1965,7 +1965,7 @@ definitions:
                   meta:xdmType: object
                   meta:xdmField: xdm:personalEmail
           allOf:
-          - "$ref": https://ns.adobe.com/xdm/common/extensible#/definitions/@context
+          - "$ref": https://ns.adobe.com/xdm/common/extensible#/definitions/%40context
             type: object
             meta:xdmType: object
           - "$ref": "#/definitions/profile-personal-details"

--- a/src/swagger-specs/schema-registry.yaml
+++ b/src/swagger-specs/schema-registry.yaml
@@ -1,24 +1,21 @@
-swagger: '2.0'
+openapi: 3.0.1
 info:
-  version: '1.0'
   title: Schema Registry API
-  description: >- 
-    Use the Schema Registry API to access the Schema Library within Adobe Experience Platform. The registry provides a user interface and RESTful API from which all available library resources are accessible. 
-    Programmatically manage all schemas and related Experience Data Model (XDM) resources available to you within Platform. This includes those defined by Adobe, Experience Platform partners, and vendors whose applications you use.
-  
+  description: |-
+    Use the Schema Registry API to access the Schema Library within Adobe Experience Platform. The registry provides a user interface and RESTful API from which all available library resources are accessible.  Programmatically manage all schemas and related Experience Data Model (XDM) resources available to you within Platform. This includes those defined by Adobe, Experience Platform partners, and vendors whose applications you use.
     * **Related documentation**:
       * [XDM documentation](http://www.adobe.com/go/xdm-home-en)
-    
+
     * **Visualize API calls with Postman (a free, third-party software)**:
       * [Schema Registry API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Schema%20Registry%20API.postman_collection.json)
       * [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)
       * [Steps for importing environments and collections in Postman](https://learning.getpostman.com/docs/postman/collection_runs/using_environments_in_collection_runs/)
-  
+
     * **API paths**:
       * PLATFORM Gateway URL: https://<span>platform.adobe.io
       * Base path for this API: /data/foundation/schemaregistry
       * Example of a complete path for making a call to "/stats": https://<span>platform.adobe.io/data/foundation/schemaregistry/stats
-    
+
     * **Required headers**:
       * All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).
       * All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, "prod"). See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.
@@ -27,2206 +24,3993 @@ info:
 
     - **API error handling**:
       * Refer to the Experience Platform API troubleshooting guide for [FAQs](https://experienceleague.adobe.com/docs/experience-platform/landing/troubleshooting.html#faq), [API status codes](https://experienceleague.adobe.com/docs/experience-platform/landing/troubleshooting.html#api-status-codes), and [request header errors](https://experienceleague.adobe.com/docs/experience-platform/landing/troubleshooting.html#request-header-errors).
-
-basePath: /data/foundation/schemaregistry
-host: platform.adobe.io
+  version: "1.0"
+servers:
+- url: //platform.adobe.io/data/foundation/schemaregistry
 tags:
-  - name: "Stats"
-    description: Returns {TENANT_ID} along with information regarding IMS Org usage of the Schema Registry such as resource counts, recently created resources, and class usage.
-  - name: "Schemas"
-    description: Schemas provide an abstract definition of a real-world object along with constraints and expectations that can be applied and used to validate data.
-  - name: "Behaviors"
-    description: Behaviors define the nature of data that a schema describes. Each XDM class must reference a specific behavior, which all schemas that employ that class will inherit. Schemas that inherit the "record" behavior provide information about the attributes of a subject, while those that inherit the "time-series" behavior provide a snapshot of the system at the time an action was taken by a record subject.
-  - name: "Classes"
-    description: Classes define behavioral aspects of the data within the schema and describe the smallest number of common properties contained in all schemas that implement the same class.
-  - name: "Field groups"
-    description: A field group is a reusable component that defines one or more fields to implement certain functions within a schema based on a compatible class.
-  - name: "Data types"
-    description: Data types are used as reference field types in classes or schemas to define complex types. Data types may define multiple sub-fields providing a consistent multi-field structure.
-  - name: "Descriptors"
-    description: Schema descriptors are tenant-level metadata used to provide interpretive details on how data based on certain schemas may relate or interact with one another.
-  - name: "Unions"
-    description: Union schemas aggregate the fields of all schemas that implement the same class (such as ExperienceEvent or Profile) into a single schema. They are used by Real-time Customer Profile to merge data together to form a "single source of truth" for an individual.
-  - name: "Export/Import"
-    description: The Schema Registry API allows you to transfer and share XDM resources between sandboxes and IMS Organizations. For any schema, field group, or data type, you can generate an export payload containing the structure of the resource and any dependent resources. This payload can then be used to import the resource into a destination sandbox and IMS Org.
-  - name: "Sample data"
-    description: You can generate sample data for any specified schema within the Schema Library. The response object returned can then be used as the source of dataset ingestion.
-  - name: "Audit log"
-    description: The Schema Registry maintains a log of all the changes that have occurred to a resource (class, field group, data type, or schema) between different updates.
-  - name: "Mixins (deprecated)"
-    description: '"Mixin" is the former term for a field group. The /mixins endpoints are deprecated and only maintained as legacy endpoints. For new implementations, please use the /fieldgroups endpoint instead.'
-consumes:
-  - application/json
-produces:
-  - application/json
+- name: Stats
+  description: "Returns {TENANT_ID} along with information regarding IMS Org usage\
+    \ of the Schema Registry such as resource counts, recently created resources,\
+    \ and class usage."
+- name: Schemas
+  description: Schemas provide an abstract definition of a real-world object along
+    with constraints and expectations that can be applied and used to validate data.
+- name: Behaviors
+  description: "Behaviors define the nature of data that a schema describes. Each\
+    \ XDM class must reference a specific behavior, which all schemas that employ\
+    \ that class will inherit. Schemas that inherit the \"record\" behavior provide\
+    \ information about the attributes of a subject, while those that inherit the\
+    \ \"time-series\" behavior provide a snapshot of the system at the time an action\
+    \ was taken by a record subject."
+- name: Classes
+  description: Classes define behavioral aspects of the data within the schema and
+    describe the smallest number of common properties contained in all schemas that
+    implement the same class.
+- name: Field groups
+  description: A field group is a reusable component that defines one or more fields
+    to implement certain functions within a schema based on a compatible class.
+- name: Data types
+  description: Data types are used as reference field types in classes or schemas
+    to define complex types. Data types may define multiple sub-fields providing a
+    consistent multi-field structure.
+- name: Descriptors
+  description: Schema descriptors are tenant-level metadata used to provide interpretive
+    details on how data based on certain schemas may relate or interact with one another.
+- name: Unions
+  description: Union schemas aggregate the fields of all schemas that implement the
+    same class (such as ExperienceEvent or Profile) into a single schema. They are
+    used by Real-time Customer Profile to merge data together to form a "single source
+    of truth" for an individual.
+- name: Export/Import
+  description: "The Schema Registry API allows you to transfer and share XDM resources\
+    \ between sandboxes and IMS Organizations. For any schema, field group, or data\
+    \ type, you can generate an export payload containing the structure of the resource\
+    \ and any dependent resources. This payload can then be used to import the resource\
+    \ into a destination sandbox and IMS Org."
+- name: Sample data
+  description: You can generate sample data for any specified schema within the Schema
+    Library. The response object returned can then be used as the source of dataset
+    ingestion.
+- name: Audit log
+  description: "The Schema Registry maintains a log of all the changes that have occurred\
+    \ to a resource (class, field group, data type, or schema) between different updates."
+- name: Mixins (deprecated)
+  description: "\"Mixin\" is the former term for a field group. The /mixins endpoints\
+    \ are deprecated and only maintained as legacy endpoints. For new implementations,\
+    \ please use the /fieldgroups endpoint instead."
 paths:
-  '/stats':
-    parameters:
-      - $ref: '#/parameters/authorization'
-      - $ref: '#/parameters/x-api-key'
-      - $ref: '#/parameters/x-gw-ims-org-id'
-      - $ref: '#/parameters/x-sandbox-name'
+  /stats:
     get:
       tags:
-      - "Stats"
-      summary: Retrieve your tenant ID and other usage information related to the Schema Registry.
+      - Stats
+      summary: Retrieve your tenant ID and other usage information related to the
+        Schema Registry.
       operationId: retrieveStats
-      produces:
-        - application/json
+      parameters:
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
       responses:
-        '200':
-          description: A successful response returns your tenant ID and Schema Registry usage information.
-          schema: 
-            '$ref': '#/definitions/statsResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
-  '/{CONTAINER_ID}/fieldgroups':
+        "200":
+          description: A successful response returns your tenant ID and Schema Registry
+            usage information.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statsResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+  /{CONTAINER_ID}/fieldgroups:
     get:
       tags:
-      - "Field groups"
+      - Field groups
       summary: List field groups
-      description: >-
+      description: |-
         Retrieve a list of field groups within the specified container.
-
         >**NOTE**: For more information on using this operation, see the [field groups endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/field-groups.html) on Experience League.
       operationId: listFieldGroups
-      produces:
-        - application/json
       parameters:
-        - $ref: '#/parameters/containerIdList'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/acceptListing'
-        - $ref: '#/parameters/property'
-        - $ref: '#/parameters/orderBy'
-        - $ref: '#/parameters/start'
-        - $ref: '#/parameters/limit'
+      - name: CONTAINER_ID
+        in: path
+        description: "The name of the container that you want to list resources from.\
+          \ To list core resources provided by Adobe, use `global`. To list custom\
+          \ resources defined by your organization, use `tenant`."
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: "The desired response format. For listing calls, the following\
+          \ `Accept` header values are permitted: \n<table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed-id+json</code></td><td>Returns\
+          \ a short summary of each resource, generally the preferred header for listing.</td></tr><tr><td><code>application/vnd.adobe.xed+json</code></td><td>Returns\
+          \ full JSON for each resource, with the original <code>$ref</code> and <code>allOf</code>\
+          \ attributes included.</td></tr></tbody></table>"
+        required: true
+        schema:
+          type: string
+      - name: property
+        in: query
+        description: "A comma-separated list of top-level object properties to be\
+          \ returned in the response. For example, `property=meta:intendedToExtend==https://ns.adobe.com/xdm/context/profile`\
+          \ returns only field groups that are compatible with the XDM Individual\
+          \ Profile class."
+        schema:
+          type: string
+      - name: orderby
+        in: query
+        description: "Sort the listed resources by specified fields. For example `orderby=title`\
+          \ sorts results by title in ascending order (A-Z). Adding a `-` before the\
+          \ field name (`orderby=-title`) sorts items in descending order (Z-A). Multiple\
+          \ fields can also be included to denote primary and secondary sort orders\
+          \ (for example, `orderby=title,description`)."
+        schema:
+          type: string
+      - name: start
+        in: query
+        description: |-
+          When used in conjunction with an `orderby` parameter, `start` specifies where the paginated list of items should begin. This parameter cannot be used without an `orderby` parameter present.
+
+          Typically, this parameter is omitted in order to obtain the first page of results. After that, `start` should be set to the maximum value of the primary sort property of the `orderby` field received in the previous page. The API response then returns entries beginning with those that have a primary sort property from `orderby` strictly greater than (for ascending) or strictly less than (for descending) the specified value.
+
+          For example, if the `orderby` parameter is set to `orderby=name,firstname`, the `start` parameter would contain a value for the `name` property. In this case, if you wanted to show the next 20 entries of a resource immediately following the name "Miller", you would use: `?orderby=name,firstname&start=Miller&limit=20`.
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: |-
+          When used in conjunction with an `orderby` parameter, `limit` restricts the maximum number of items that should be returned for a given request. This parameter cannot be used without an `orderby` parameter present.
+
+          The `limit` parameter specifies a positive integer (between `0` and `500`) as a *hint* as to the maximum number of items that should be returned. For example, `limit=5` returns only five resources in the list. However, this value is not strictly honored. The actual response size may be smaller or larger as constrained by the need to provide the reliable operation of the `start` parameter, if one is provided.
+        schema:
+          type: number
       responses:
-        '200':
-          description: A successful response returns all field groups in the specified container.
-          schema:
-            $ref: '#/definitions/listFieldGroupsResponse'
-        '400':
-          description: The `Accept` header is invalid or missing. Ensure that you are providing a valid `Accept` header for a listing call with no version supplied (e.g. `application/vnd.adobe.xed-id+json`) before trying again.
-          schema:
-           $ref: '#/definitions/acceptErrorList' 
-        
-  '/{CONTAINER_ID}/fieldgroups/{FIELD_GROUP_ID}':
+        "200":
+          description: A successful response returns all field groups in the specified
+            container.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/listFieldGroupsResponse'
+        "400":
+          description: The `Accept` header is invalid or missing. Ensure that you
+            are providing a valid `Accept` header for a listing call with no version
+            supplied (e.g. `application/vnd.adobe.xed-id+json`) before trying again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/acceptErrorList'
+  /{CONTAINER_ID}/fieldgroups/{FIELD_GROUP_ID}:
     get:
       tags:
-      - "Field groups"
-      parameters:
-      - $ref: '#/parameters/containerIdLookup'
-      - name: FIELD_GROUP_ID
-        description: The `meta:altId` or URL-encoded `$id` of the field group you want to look up.
-        required: true
-        in: path
-        type: string
-      - $ref: '#/parameters/authorization'
-      - $ref: '#/parameters/x-api-key'
-      - $ref: '#/parameters/x-gw-ims-org-id'
-      - $ref: '#/parameters/x-sandbox-name'
-      - $ref: '#/parameters/accept'
+      - Field groups
       summary: Retrieve a field group
-      description: >-
-        >**NOTE**: For more information on using this operation, see the [field groups endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/field-groups.html) on Experience League.
+      description: ">**NOTE**: For more information on using this operation, see the\
+        \ [field groups endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/field-groups.html)\
+        \ on Experience League."
       operationId: retrieveFieldGroup
-      produces:
-        - application/json
+      parameters:
+      - name: CONTAINER_ID
+        in: path
+        description: "The name of the container that you want to retrieve a resource\
+          \ from. To retrieve a core resource provided by Adobe, use `global`. To\
+          \ retrieve a custom resource defined by your organization, use `tenant`."
+        required: true
+        schema:
+          type: string
+      - name: FIELD_GROUP_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the field group you
+          want to look up.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: |-
+          The desired response format. For lookup requests, a `version` parameter must be included, with the following `Accept` header values being permitted:
+          <table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed+json; version=1</code></td><td>Returns only the basic details of the resource, with all inherited fields relegated to <code>$ref</code> and <code>allOf</code> properties.</td></tr><tr><td><code>application/vnd.adobe.xed-full+json; version=1</code></td><td>Returns the full details of the resource, including the details all fields inherited from other resources.</td></tr><tr><td><code>application/vnd.adobe.xed-notext+json; version=1</code></td><td>Returns only the basic details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-notext+json; version=1</code></td><td>Returns the full details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-desc+json; version=1</code></td><td>Returns the full details of the resource, including descriptions but with no titles.</td></tr></tbody></table>
+        required: true
+        schema:
+          type: string
       responses:
-        '200':
+        "200":
           description: A successful response returns the details of the field group.
-          schema:
-            $ref: '#/definitions/lookupFieldGroupResponse'
-        '400':
-          description: The `Accept` header is invalid or missing. Ensure that you are providing a valid accept header for a lookup call including a version number (e.g. `application/vnd.adobe.xed+json;version=1`) before trying again.
-          schema:
-            $ref: '#/definitions/acceptErrorLookup'
-        
-  '/tenant/fieldgroups':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/lookupFieldGroupResponse'
+        "400":
+          description: The `Accept` header is invalid or missing. Ensure that you
+            are providing a valid accept header for a lookup call including a version
+            number (e.g. `application/vnd.adobe.xed+json;version=1`) before trying
+            again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/acceptErrorLookup'
+  /tenant/fieldgroups:
     post:
       tags:
-      - "Field groups"
+      - Field groups
       summary: Create a custom field group
-      description: >-
-        >**NOTE**: For more information on using this operation, see the [field groups endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/field-groups.html) on Experience League.
+      description: ">**NOTE**: For more information on using this operation, see the\
+        \ [field groups endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/field-groups.html)\
+        \ on Experience League."
       operationId: createFieldGroup
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'        
-        - $ref: '#/parameters/fieldGroupPayload'
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: The JSON payload must include a 'meta:intendedToExtend' field
+          listing the '$id' of the class(es) with which the field group is compatible.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/createFieldGroup'
+        required: true
       responses:
-        '201':
+        "201":
           description: A successful response returns the details of the field group.
-          schema:
-            $ref: '#/definitions/createFieldGroupResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
-  '/tenant/fieldgroups/{FIELD_GROUP_ID}':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/createFieldGroupResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      x-codegen-request-body-name: body
+  /tenant/fieldgroups/{FIELD_GROUP_ID}:
     put:
       tags:
-      - "Field groups"
+      - Field groups
       summary: Update a custom field group
-      description: >-
+      description: |-
         A PUT request essentially re-writes the field group, therefore the request body must include all fields required to create (POST) a field group. This is especially useful when updating a lot of information in the field group at once.
-
 
 
         >**NOTE**: For more information on using this operation, see the [field groups endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/field-groups.html) on Experience League.
       operationId: updateFieldGroup
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
-        - name: FIELD_GROUP_ID
-          description: The `meta:altId` or URL-encoded `$id` of the field group you want to update.
-          required: true
-          in: path
+      - name: FIELD_GROUP_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the field group you
+          want to update.
+        required: true
+        schema:
           type: string
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'
-        - $ref: '#/parameters/replaceFieldGroupPayload'
-      responses:
-        '200':
-          description: A successful response returns the details of the updated field group.
-          schema:
-            $ref: '#/definitions/updateFieldGroupResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
-    patch:
-      tags:
-      - "Field groups"
-      summary: Update a custom field group
-      description: >-
-        You can use this endpoint to update one or more attributes of your custom field group.
-
-        The Schema Registry supports all standard JSON Patch operations, including `add`, `remove`, and `replace`, to allow you to modify or update resources you have defined.
-        
-        
-        >**NOTE**: For more information on JSON Patch, including all available operations, please refer to the [the official JSON Patch specification](https://datatracker.ietf.org/doc/html/rfc6902).
-        >
-        >For more information on using this operation, see the [field groups endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/field-groups.html) on Experience League.
-      operationId: patchFieldGroup
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - name: FIELD_GROUP_ID
-          description: The `meta:altId` or URL-encoded `$id` of the field group you want to update.
-          required: true
-          in: path
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
           type: string
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'
-        - $ref: '#/parameters/patchFieldGroupPayload'
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: "The JSON payload must include all of the fields that were originally\
+          \ required for creating the field group, but with updated values. This includes\
+          \ an `allOf` attribute referencing the `$id` of the class the schema will\
+          \ implement."
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/replaceFieldGroup'
+        required: true
       responses:
-        '200':
-          description: A successful response returns the details of the updated field group.
-          schema:
-            $ref: '#/definitions/patchFieldGroupResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
+        "200":
+          description: A successful response returns the details of the updated field
+            group.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/updateFieldGroupResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      x-codegen-request-body-name: body
     delete:
       tags:
-      - "Field groups"
+      - Field groups
       summary: Delete a custom field group
-      description: >-
+      description: |-
         You can remove an existing field group through a DELETE request. A successful deletion returns an empty response body and HTTP status 204 (No Content).
-
 
         >**NOTE**: For more information on using this operation, see the [field groups endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/field-groups.html) on Experience League.
       operationId: removeFieldGroup
       parameters:
-        - name: FIELD_GROUP_ID
-          description: The `meta:altId` or URL-encoded `$id` of the field group you want to delete.
-          required: true
-          in: path
+      - name: FIELD_GROUP_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the field group you
+          want to delete.
+        required: true
+        schema:
           type: string
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
       responses:
-        '204':
-          description: A successful response returns an empty response body and HTTP status 204 (No Content), indicating that the field group has been deleted.
-  '/{CONTAINER_ID}/schemas':
+        "204":
+          description: "A successful response returns an empty response body and HTTP\
+            \ status 204 (No Content), indicating that the field group has been deleted."
+          content: {}
+    patch:
+      tags:
+      - Field groups
+      summary: Update a custom field group
+      description: |-
+        You can use this endpoint to update one or more attributes of your custom field group.
+        The Schema Registry supports all standard JSON Patch operations, including `add`, `remove`, and `replace`, to allow you to modify or update resources you have defined.
+
+        >**NOTE**: For more information on JSON Patch, including all available operations, please refer to the [the official JSON Patch specification](https://datatracker.ietf.org/doc/html/rfc6902). > >For more information on using this operation, see the [field groups endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/field-groups.html) on Experience League.
+      operationId: patchFieldGroup
+      parameters:
+      - name: FIELD_GROUP_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the field group you
+          want to update.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: The request body accepts a JSON Patch payload.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/patchFieldGroup'
+        required: true
+      responses:
+        "200":
+          description: A successful response returns the details of the updated field
+            group.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/patchFieldGroupResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      x-codegen-request-body-name: body
+  /{CONTAINER_ID}/schemas:
     get:
       tags:
-      - "Schemas"
+      - Schemas
       summary: List schemas
-      description: >-
+      description: |-
         You can list schemas within the global or tenant container by performing a GET request. To help filter results, the Schema Registry supports the use of query parameters when listing resources.
-
 
         >**NOTE**: For more information on using this operation, see the [schemas endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/schemas.html) on Experience League.
       operationId: listSchemas
-      produces:
-        - application/json
       parameters:
-        - $ref: '#/parameters/containerIdList'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/acceptListing'
-        - $ref: '#/parameters/property'
-        - $ref: '#/parameters/orderBy'
-        - $ref: '#/parameters/start'
-        - $ref: '#/parameters/limit'
+      - name: CONTAINER_ID
+        in: path
+        description: "The name of the container that you want to list resources from.\
+          \ To list core resources provided by Adobe, use `global`. To list custom\
+          \ resources defined by your organization, use `tenant`."
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: "The desired response format. For listing calls, the following\
+          \ `Accept` header values are permitted: \n<table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed-id+json</code></td><td>Returns\
+          \ a short summary of each resource, generally the preferred header for listing.</td></tr><tr><td><code>application/vnd.adobe.xed+json</code></td><td>Returns\
+          \ full JSON for each resource, with the original <code>$ref</code> and <code>allOf</code>\
+          \ attributes included.</td></tr></tbody></table>"
+        required: true
+        schema:
+          type: string
+      - name: property
+        in: query
+        description: "A comma-separated list of top-level object properties to be\
+          \ returned in the response. For example, `property=meta:intendedToExtend==https://ns.adobe.com/xdm/context/profile`\
+          \ returns only field groups that are compatible with the XDM Individual\
+          \ Profile class."
+        schema:
+          type: string
+      - name: orderby
+        in: query
+        description: "Sort the listed resources by specified fields. For example `orderby=title`\
+          \ sorts results by title in ascending order (A-Z). Adding a `-` before the\
+          \ field name (`orderby=-title`) sorts items in descending order (Z-A). Multiple\
+          \ fields can also be included to denote primary and secondary sort orders\
+          \ (for example, `orderby=title,description`)."
+        schema:
+          type: string
+      - name: start
+        in: query
+        description: |-
+          When used in conjunction with an `orderby` parameter, `start` specifies where the paginated list of items should begin. This parameter cannot be used without an `orderby` parameter present.
+
+          Typically, this parameter is omitted in order to obtain the first page of results. After that, `start` should be set to the maximum value of the primary sort property of the `orderby` field received in the previous page. The API response then returns entries beginning with those that have a primary sort property from `orderby` strictly greater than (for ascending) or strictly less than (for descending) the specified value.
+
+          For example, if the `orderby` parameter is set to `orderby=name,firstname`, the `start` parameter would contain a value for the `name` property. In this case, if you wanted to show the next 20 entries of a resource immediately following the name "Miller", you would use: `?orderby=name,firstname&start=Miller&limit=20`.
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: |-
+          When used in conjunction with an `orderby` parameter, `limit` restricts the maximum number of items that should be returned for a given request. This parameter cannot be used without an `orderby` parameter present.
+
+          The `limit` parameter specifies a positive integer (between `0` and `500`) as a *hint* as to the maximum number of items that should be returned. For example, `limit=5` returns only five resources in the list. However, this value is not strictly honored. The actual response size may be smaller or larger as constrained by the need to provide the reliable operation of the `start` parameter, if one is provided.
+        schema:
+          type: number
       responses:
-        '200':
-          description: A successful response returns a list of all schemas in the container with format dependent on the `Accept` header.
-          schema:
-            $ref: '#/definitions/listSchemasResponse'
-        '400':
-          description: The `Accept` header is invalid or missing. Ensure that you are providing a valid `Accept` header for a listing call with no version supplied (e.g. `application/vnd.adobe.xed-id+json`) before trying again.
-          schema:
-           $ref: '#/definitions/acceptErrorList' 
-        
-  '/{CONTAINER_ID}/schemas/{SCHEMA_ID}':
+        "200":
+          description: A successful response returns a list of all schemas in the
+            container with format dependent on the `Accept` header.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/listSchemasResponse'
+        "400":
+          description: The `Accept` header is invalid or missing. Ensure that you
+            are providing a valid `Accept` header for a listing call with no version
+            supplied (e.g. `application/vnd.adobe.xed-id+json`) before trying again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/acceptErrorList'
+  /{CONTAINER_ID}/schemas/{SCHEMA_ID}:
     get:
       tags:
-      - "Schemas"
-      parameters:
-      - $ref: '#/parameters/containerIdLookup'
-      - $ref: '#/parameters/SCHEMA_ID'
-      - $ref: '#/parameters/authorization'
-      - $ref: '#/parameters/x-api-key'
-      - $ref: '#/parameters/x-gw-ims-org-id'
-      - $ref: '#/parameters/x-sandbox-name'
-      - $ref: '#/parameters/accept'
+      - Schemas
       summary: Retrieve a schema
-      description: >-
-        >**NOTE**: For more information on using this operation, see the [schemas endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/schemas.html) on Experience League.
+      description: ">**NOTE**: For more information on using this operation, see the\
+        \ [schemas endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/schemas.html)\
+        \ on Experience League."
       operationId: retrieveSchema
-      produces:
-        - application/json
+      parameters:
+      - name: CONTAINER_ID
+        in: path
+        description: "The name of the container that you want to retrieve a resource\
+          \ from. To retrieve a core resource provided by Adobe, use `global`. To\
+          \ retrieve a custom resource defined by your organization, use `tenant`."
+        required: true
+        schema:
+          type: string
+      - name: SCHEMA_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the schema in question.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: |-
+          The desired response format. For lookup requests, a `version` parameter must be included, with the following `Accept` header values being permitted:
+          <table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed+json; version=1</code></td><td>Returns only the basic details of the resource, with all inherited fields relegated to <code>$ref</code> and <code>allOf</code> properties.</td></tr><tr><td><code>application/vnd.adobe.xed-full+json; version=1</code></td><td>Returns the full details of the resource, including the details all fields inherited from other resources.</td></tr><tr><td><code>application/vnd.adobe.xed-notext+json; version=1</code></td><td>Returns only the basic details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-notext+json; version=1</code></td><td>Returns the full details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-desc+json; version=1</code></td><td>Returns the full details of the resource, including descriptions but with no titles.</td></tr></tbody></table>
+        required: true
+        schema:
+          type: string
       responses:
-        '200':
+        "200":
           description: A successful response returns the details of the schema.
-          schema:
-            $ref: '#/definitions/lookupSchemaResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/lookupSchemaResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+        "404":
           description: The resource is not found.
-        '406':
-          description: The specified `Accept` format/version is not available for this resource.
-        
-  '/tenant/schemas':
+          content: {}
+        "406":
+          description: The specified `Accept` format/version is not available for
+            this resource.
+          content: {}
+  /tenant/schemas:
     post:
       tags:
-      - "Schemas"
+      - Schemas
       summary: Create a custom schema
-      description: >-
-        >**NOTE**: For more information on using this operation, see the [schemas endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/schemas.html) on Experience League.
+      description: ">**NOTE**: For more information on using this operation, see the\
+        \ [schemas endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/schemas.html)\
+        \ on Experience League."
       operationId: createSchema
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'
-        - $ref: '#/parameters/createSchemaPayload'
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: The JSON payload must include an `allOf` attribute referencing
+          the `$id` of the base class the that the schema will implement.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/createSchema'
+        required: true
       responses:
-        '201':
-          description: A successful response returns the details of the newly created schema.
-          schema: 
-            '$ref': '#/definitions/createSchemaResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
-  '/tenant/schemas/{SCHEMA_ID}':
+        "201":
+          description: A successful response returns the details of the newly created
+            schema.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/createSchemaResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      x-codegen-request-body-name: body
+  /tenant/schemas/{SCHEMA_ID}:
     put:
       tags:
-      - "Schemas"
+      - Schemas
       summary: Update a custom schema
-      description: >-
+      description: |-
         A PUT request essentially re-writes the schema, therefore the request body must include all fields required to create (POST) a schema. This is especially useful when updating a lot of information in the schema at once.
-
 
         >**NOTE**: For more information on using this operation, see the [schemas endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/schemas.html) on Experience League.
       operationId: updateSchema
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
-        - $ref: '#/parameters/SCHEMA_ID'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'
-        - $ref: '#/parameters/replaceSchemaPayload'
+      - name: SCHEMA_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the schema in question.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: "The JSON payload must include all of the fields that were originally\
+          \ required for creating the schema, but with updated values. This includes\
+          \ an `allOf` attribute referencing the `$id` of the class the schema will\
+          \ implement."
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/replaceSchema'
+        required: true
       responses:
-        '200':
+        "200":
           description: A successful response returns JSON schema with updated attributes.
-          schema: 
-            '$ref': '#/definitions/updateSchemaResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
-    patch:
-      tags:
-        - "Schemas"
-      summary: Update one or more attributes of a custom schema
-      description: >-
-        You can use this endpoint to update one or more attributes of the custom schema.
-
-        
-        The Schema Registry supports all standard JSON Patch operations, including `add`, `remove`, and `replace`. For more information on JSON Patch, including all available operations, please refer to the [the official JSON Patch specification](https://datatracker.ietf.org/doc/html/rfc6902).
-
-
-        >**NOTE**: For more information on using this operation, see the [schemas endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/schemas.html) on Experience League.
-      operationId: patchSchema
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: '#/parameters/SCHEMA_ID'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'
-        - $ref: '#/parameters/patchPayload'
-      responses:
-        '200':
-          description: A successful response returns JSON schema with updated attributes.
-          schema:
-            $ref: '#/definitions/patchSchemaResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
-   
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/updateSchemaResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      x-codegen-request-body-name: body
     delete:
       tags:
-      - "Schemas"
+      - Schemas
       summary: Delete a custom schema
-      description: >-
+      description: |-
         You can remove an existing schema by performing a DELETE request. A successful deletion returns an empty response body and HTTP status 204 (No Content).
-
 
         >**NOTE**: For more information on using this operation, see the [schemas endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/schemas.html) on Experience League.
       operationId: deleteSchema
       parameters:
-        - $ref: '#/parameters/SCHEMA_ID'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
+      - name: SCHEMA_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the schema in question.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
       responses:
-        '204':
-          description: A successful response returns an empty response body and HTTP status 204 (No Content), indicating that the schema has been deleted.
-        '404':
+        "204":
+          description: "A successful response returns an empty response body and HTTP\
+            \ status 204 (No Content), indicating that the schema has been deleted."
+          content: {}
+        "404":
           description: The resource is not found.
-        '500':
-         description: An internal server error occurred.
-  '/global/behaviors':
-    get:
-      tags:
-        - "Behaviors"
-      summary: List behaviors
-      description: >-
-        >**NOTE**: For more information on using this operation, see the [behaviors endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/behaviors.html) on Experience League.
-      operationId: listBehaviors
-      produces:
-        - application/json
-      parameters:
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/acceptListing'
-      responses:
-        '200':
-          description: A successful response returns all behaviors in the global container.
-          schema:
-            allOf:
-              - $ref: '#/definitions/listResponse'
-            example:
-              "results":
-                - "$id": "https://ns.adobe.com/xdm/data/record"
-                  "meta:altId": "_xdm.data.record"
-                  "version": "1.16.4"
-                  "title": "Record Schema"
-                - "$id": "https://ns.adobe.com/xdm/data/adhoc"
-                  "meta:altId": "_xdm.data.adhoc"
-                  "version": "1.16.4"
-                  "title": "Ad Hoc Schema"
-                - "$id": "https://ns.adobe.com/xdm/data/time-series"
-                  "meta:altId": "_xdm.data.time-series"
-                  "version": "1.16.4"
-                  "title": "Time-series Schema"
-              "_page":
-                "orderby": "updated"
-                "next": null
-                "count": 3
-              "_links":
-                "next": null
-        '400':
-          description: The `Accept` header is invalid or missing. Ensure that you are providing a valid `Accept` header for a listing call with no version supplied (e.g. `application/vnd.adobe.xed-id+json`) before trying again.
-          schema:
-           $ref: '#/definitions/acceptErrorList' 
-  '/global/behaviors/{BEHAVIOR_ID}':
-    get:
-      tags:
-        - "Behaviors"
-      summary: Retrieve a behavior
-      description: >-
-        >**NOTE**: For more information on using this operation, see the [behaviors endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/behaviors.html) on Experience League.
-      operationId: retrieveBehavior
-      produces:
-        - application/json
-      parameters:
-        - $ref: '#/parameters/BEHAVIOR_ID'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/accept'
-      responses:
-        '200':
-          description: A successful response returns the details of the behavior specified in the request path.
-          schema:
-            $ref: '#/definitions/singleBehaviorResponse'
-        '400':
-          description: The `Accept` header is invalid or missing. Ensure that you are providing a valid accept header for a lookup call including a version number (e.g. `application/vnd.adobe.xed+json;version=1`) before trying again.
-          schema:
-            $ref: '#/definitions/acceptErrorLookup'
-  '/{CONTAINER_ID}/mixins':
-    get:
-      tags:
-      - "Mixins (deprecated)"
-      summary: List all mixins
-      description: >-
-        **NOTE**: This endpoint is deprecated. For future implementations, please use the [equivalent operation](#operation/listFieldGroups) for the field groups endpoint instead.
-      deprecated: true
-      operationId: listMixins
-      produces:
-        - application/json
-      parameters:
-        - $ref: '#/parameters/containerIdList'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/acceptListing'
-        - $ref: '#/parameters/property'
-        - $ref: '#/parameters/orderBy'
-        - $ref: '#/parameters/start'
-        - $ref: '#/parameters/limit'
-      responses:
-        '200':
-          description: A successful response returns all mixins in the specified container.
-          schema:
-            $ref: '#/definitions/listFieldGroupsResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
-  '/{CONTAINER_ID}/mixins/{MIXIN_ID}':
-    get:
-      tags:
-      - "Mixins (deprecated)"
-      parameters:
-      - $ref: '#/parameters/containerIdLookup'
-      - $ref: '#/parameters/MIXIN_ID'
-      - $ref: '#/parameters/authorization'
-      - $ref: '#/parameters/x-api-key'
-      - $ref: '#/parameters/x-gw-ims-org-id'
-      - $ref: '#/parameters/x-sandbox-name'
-      - $ref: '#/parameters/accept'
-      summary: Retrieve a mixin
-      deprecated: true
-      description: >-
-        **NOTE**: This endpoint is deprecated. For future implementations, please use the [equivalent operation](#operation/retrieveFieldGroup) for the field groups endpoint instead.
-      operationId: lookupMixin
-      produces:
-        - application/json
-      responses:
-        '200':
-          description: A successful response returns the details of the mixin.
-          schema:
-            $ref: '#/definitions/lookupFieldGroupResponse'
-        '404':
-          description: The resource is not found.
-        '406':
-          description: The specified `Accept` format/version is not available for this resource.
-        
-  '/tenant/mixins':
-    post:
-      tags:
-      - "Mixins (deprecated)"
-      summary: Create a new custom mixin
-      description: >-
-        **NOTE**: This endpoint is deprecated. For future implementations, please use the [equivalent operation](#operation/createFieldGroup) for the field groups endpoint instead.
-      deprecated: true
-      operationId: createMixin
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'        
-        - $ref: '#/parameters/fieldGroupPayload'
-      responses:
-        '201':
-          description: A successful response returns the details of the mixin.
-          schema:
-            $ref: '#/definitions/createFieldGroupResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
-  '/tenant/mixins/{MIXIN_ID}':
-    put:
-      tags:
-      - "Mixins (deprecated)"
-      summary: Update a custom mixin
-      deprecated: true
-      description: >-
-        **NOTE**: This endpoint is deprecated. For future implementations, please use the [equivalent operation](#operation/updateFieldGroup) for the field groups endpoint instead.
-      operationId: replaceMixin
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: '#/parameters/MIXIN_ID'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'
-        - $ref: '#/parameters/replaceFieldGroupPayload'
-      responses:
-        '200':
-          description: A successful response returns the details of the updated mixin.
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
+          content: {}
+        "500":
+          description: An internal server error occurred.
+          content: {}
     patch:
       tags:
-      - "Mixins (deprecated)"
-      summary: Update custom mixin
-      deprecated: true
-      description: >-
-        **NOTE**: This endpoint is deprecated. For future implementations, please use the [equivalent operation](#operation/patchFieldGroup) for the field groups endpoint instead.
-      operationId: updateMixin
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      - Schemas
+      summary: Update one or more attributes of a custom schema
+      description: |-
+        You can use this endpoint to update one or more attributes of the custom schema.
+
+        The Schema Registry supports all standard JSON Patch operations, including `add`, `remove`, and `replace`. For more information on JSON Patch, including all available operations, please refer to the [the official JSON Patch specification](https://datatracker.ietf.org/doc/html/rfc6902).
+
+        >**NOTE**: For more information on using this operation, see the [schemas endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/schemas.html) on Experience League.
+      operationId: patchSchema
       parameters:
-        - $ref: '#/parameters/MIXIN_ID'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'
-        - $ref: '#/parameters/patchFieldGroupPayload'
-      responses:
-        '200':
-          description: A successful response returns the details of the updated mixin.
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
-    delete:
-      tags:
-      - "Mixins (deprecated)"
-      summary: Delete a custom mixin
-      deprecated: true
-      description: >-
-        **NOTE**: This endpoint is deprecated. For future implementations, please use the [equivalent operation](#operation/removeFieldGroup) for the field groups endpoint instead.
-      operationId: removeMixin
-      parameters:
-        - $ref: '#/parameters/MIXIN_ID'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-      responses:
-        '204':
-          description: A successful response returns an empty response body and HTTP status 204 (No Content), indicating that the mixin has been deleted.
-        '404':
-          description: The resource is not found.
-        '500':
-         description: An internal server error occurred.
-  '/{CONTAINER_ID}/classes':
-    get:
-      tags:
-      - "Classes"
-      summary: List classes
-      description: >-
-        >**NOTE**: For more information on using this operation, see the [classes endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/classes.html) on Experience League.
-      operationId: listClasses
-      produces:
-        - application/json
-      parameters:
-        - $ref: '#/parameters/containerIdList'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/acceptListing'
-        - $ref: '#/parameters/property'
-        - $ref: '#/parameters/orderBy'
-        - $ref: '#/parameters/start'
-        - $ref: '#/parameters/limit'
-      responses:
-        '200':
-          description: A successful response returns a list of all classes in the container.
-          schema:
-            $ref: '#/definitions/listClassesResponse'
-        '400':
-          description: The `Accept` header is invalid or missing. Ensure that you are providing a valid `Accept` header for a listing call with no version supplied (e.g. `application/vnd.adobe.xed-id+json`) before trying again.
-          schema:
-           $ref: '#/definitions/acceptErrorList' 
-        
-  '/{CONTAINER_ID}/classes/{CLASS_ID}':
-    get:
-      tags:
-      - "Classes"
-      parameters:
-        - $ref: '#/parameters/containerIdLookup'
-        - name: CLASS_ID
-          description: The `meta:altId` or URL-encoded `$id` of the class you want to look up.
-          required: true
-          in: path
+      - name: SCHEMA_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the schema in question.
+        required: true
+        schema:
           type: string
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/accept'
-      summary: Retrieve a class
-      description: >-
-        >**NOTE**: For more information on using this operation, see the [classes endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/classes.html) on Experience League.
-      operationId: retrieveClass
-      produces:
-        - application/json
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: The request body accepts a JSON Patch payload.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/patchSchema'
+        required: true
       responses:
-        '200':
-          description: A successful response returns the details of the class.
-          schema:
-            $ref: '#/definitions/lookupClassResponse'
-        '400':
-          description: The `Accept` header is invalid or missing. Ensure that you are providing a valid `Accept` header for a single lookup call, including a major version (e.g. `application/vnd.adobe.xed-id+json; version=1`) before trying again.
-          schema:
-            $ref: '#/definitions/acceptErrorLookup'
-        '404':
+        "200":
+          description: A successful response returns JSON schema with updated attributes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/patchSchemaResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      x-codegen-request-body-name: body
+  /global/behaviors:
+    get:
+      tags:
+      - Behaviors
+      summary: List behaviors
+      description: ">**NOTE**: For more information on using this operation, see the\
+        \ [behaviors endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/behaviors.html)\
+        \ on Experience League."
+      operationId: listBehaviors
+      parameters:
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: "The desired response format. For listing calls, the following\
+          \ `Accept` header values are permitted: \n<table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed-id+json</code></td><td>Returns\
+          \ a short summary of each resource, generally the preferred header for listing.</td></tr><tr><td><code>application/vnd.adobe.xed+json</code></td><td>Returns\
+          \ full JSON for each resource, with the original <code>$ref</code> and <code>allOf</code>\
+          \ attributes included.</td></tr></tbody></table>"
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: A successful response returns all behaviors in the global container.
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/listResponse'
+        "400":
+          description: The `Accept` header is invalid or missing. Ensure that you
+            are providing a valid `Accept` header for a listing call with no version
+            supplied (e.g. `application/vnd.adobe.xed-id+json`) before trying again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/acceptErrorList'
+  /global/behaviors/{BEHAVIOR_ID}:
+    get:
+      tags:
+      - Behaviors
+      summary: Retrieve a behavior
+      description: ">**NOTE**: For more information on using this operation, see the\
+        \ [behaviors endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/behaviors.html)\
+        \ on Experience League."
+      operationId: retrieveBehavior
+      parameters:
+      - name: BEHAVIOR_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the behavior in question.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: |-
+          The desired response format. For lookup requests, a `version` parameter must be included, with the following `Accept` header values being permitted:
+          <table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed+json; version=1</code></td><td>Returns only the basic details of the resource, with all inherited fields relegated to <code>$ref</code> and <code>allOf</code> properties.</td></tr><tr><td><code>application/vnd.adobe.xed-full+json; version=1</code></td><td>Returns the full details of the resource, including the details all fields inherited from other resources.</td></tr><tr><td><code>application/vnd.adobe.xed-notext+json; version=1</code></td><td>Returns only the basic details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-notext+json; version=1</code></td><td>Returns the full details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-desc+json; version=1</code></td><td>Returns the full details of the resource, including descriptions but with no titles.</td></tr></tbody></table>
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: A successful response returns the details of the behavior specified
+            in the request path.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/singleBehaviorResponse'
+        "400":
+          description: The `Accept` header is invalid or missing. Ensure that you
+            are providing a valid accept header for a lookup call including a version
+            number (e.g. `application/vnd.adobe.xed+json;version=1`) before trying
+            again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/acceptErrorLookup'
+  /{CONTAINER_ID}/mixins:
+    get:
+      tags:
+      - Mixins (deprecated)
+      summary: List all mixins
+      description: "**NOTE**: This endpoint is deprecated. For future implementations,\
+        \ please use the [equivalent operation](#operation/listFieldGroups) for the\
+        \ field groups endpoint instead."
+      operationId: listMixins
+      parameters:
+      - name: CONTAINER_ID
+        in: path
+        description: "The name of the container that you want to list resources from.\
+          \ To list core resources provided by Adobe, use `global`. To list custom\
+          \ resources defined by your organization, use `tenant`."
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: "The desired response format. For listing calls, the following\
+          \ `Accept` header values are permitted: \n<table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed-id+json</code></td><td>Returns\
+          \ a short summary of each resource, generally the preferred header for listing.</td></tr><tr><td><code>application/vnd.adobe.xed+json</code></td><td>Returns\
+          \ full JSON for each resource, with the original <code>$ref</code> and <code>allOf</code>\
+          \ attributes included.</td></tr></tbody></table>"
+        required: true
+        schema:
+          type: string
+      - name: property
+        in: query
+        description: "A comma-separated list of top-level object properties to be\
+          \ returned in the response. For example, `property=meta:intendedToExtend==https://ns.adobe.com/xdm/context/profile`\
+          \ returns only field groups that are compatible with the XDM Individual\
+          \ Profile class."
+        schema:
+          type: string
+      - name: orderby
+        in: query
+        description: "Sort the listed resources by specified fields. For example `orderby=title`\
+          \ sorts results by title in ascending order (A-Z). Adding a `-` before the\
+          \ field name (`orderby=-title`) sorts items in descending order (Z-A). Multiple\
+          \ fields can also be included to denote primary and secondary sort orders\
+          \ (for example, `orderby=title,description`)."
+        schema:
+          type: string
+      - name: start
+        in: query
+        description: |-
+          When used in conjunction with an `orderby` parameter, `start` specifies where the paginated list of items should begin. This parameter cannot be used without an `orderby` parameter present.
+
+          Typically, this parameter is omitted in order to obtain the first page of results. After that, `start` should be set to the maximum value of the primary sort property of the `orderby` field received in the previous page. The API response then returns entries beginning with those that have a primary sort property from `orderby` strictly greater than (for ascending) or strictly less than (for descending) the specified value.
+
+          For example, if the `orderby` parameter is set to `orderby=name,firstname`, the `start` parameter would contain a value for the `name` property. In this case, if you wanted to show the next 20 entries of a resource immediately following the name "Miller", you would use: `?orderby=name,firstname&start=Miller&limit=20`.
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: |-
+          When used in conjunction with an `orderby` parameter, `limit` restricts the maximum number of items that should be returned for a given request. This parameter cannot be used without an `orderby` parameter present.
+
+          The `limit` parameter specifies a positive integer (between `0` and `500`) as a *hint* as to the maximum number of items that should be returned. For example, `limit=5` returns only five resources in the list. However, this value is not strictly honored. The actual response size may be smaller or larger as constrained by the need to provide the reliable operation of the `start` parameter, if one is provided.
+        schema:
+          type: number
+      responses:
+        "200":
+          description: A successful response returns all mixins in the specified container.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/listFieldGroupsResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      deprecated: true
+  /{CONTAINER_ID}/mixins/{MIXIN_ID}:
+    get:
+      tags:
+      - Mixins (deprecated)
+      summary: Retrieve a mixin
+      description: "**NOTE**: This endpoint is deprecated. For future implementations,\
+        \ please use the [equivalent operation](#operation/retrieveFieldGroup) for\
+        \ the field groups endpoint instead."
+      operationId: lookupMixin
+      parameters:
+      - name: CONTAINER_ID
+        in: path
+        description: "The name of the container that you want to retrieve a resource\
+          \ from. To retrieve a core resource provided by Adobe, use `global`. To\
+          \ retrieve a custom resource defined by your organization, use `tenant`."
+        required: true
+        schema:
+          type: string
+      - name: MIXIN_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the mixin in question.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: |-
+          The desired response format. For lookup requests, a `version` parameter must be included, with the following `Accept` header values being permitted:
+          <table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed+json; version=1</code></td><td>Returns only the basic details of the resource, with all inherited fields relegated to <code>$ref</code> and <code>allOf</code> properties.</td></tr><tr><td><code>application/vnd.adobe.xed-full+json; version=1</code></td><td>Returns the full details of the resource, including the details all fields inherited from other resources.</td></tr><tr><td><code>application/vnd.adobe.xed-notext+json; version=1</code></td><td>Returns only the basic details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-notext+json; version=1</code></td><td>Returns the full details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-desc+json; version=1</code></td><td>Returns the full details of the resource, including descriptions but with no titles.</td></tr></tbody></table>
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: A successful response returns the details of the mixin.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/lookupFieldGroupResponse'
+        "404":
           description: The resource is not found.
-        
-  '/tenant/classes':
+          content: {}
+        "406":
+          description: The specified `Accept` format/version is not available for
+            this resource.
+          content: {}
+      deprecated: true
+  /tenant/mixins:
     post:
       tags:
-      - "Classes"
-      summary: Create a custom class
-      description: >-
-        >**NOTE**: For more information on using this operation, see the [classes endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/classes.html) on Experience League.
-      operationId: createClass
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      - Mixins (deprecated)
+      summary: Create a new custom mixin
+      description: "**NOTE**: This endpoint is deprecated. For future implementations,\
+        \ please use the [equivalent operation](#operation/createFieldGroup) for the\
+        \ field groups endpoint instead."
+      operationId: createMixin
       parameters:
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'
-        - $ref: '#/parameters/createClassPayload'
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: The JSON payload must include a 'meta:intendedToExtend' field
+          listing the '$id' of the class(es) with which the field group is compatible.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/createFieldGroup'
+        required: true
       responses:
-        '201':
-          description: A successful response returns the details of the newly created class.
-          schema: 
-            '$ref': '#/definitions/createClassResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
-    
-  '/tenant/classes/{CLASS_ID}':
+        "201":
+          description: A successful response returns the details of the mixin.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/createFieldGroupResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      deprecated: true
+      x-codegen-request-body-name: body
+  /tenant/mixins/{MIXIN_ID}:
     put:
       tags:
-      - "Classes"
-      summary: Update a custom class
-      description: >-
-        A PUT request essentially re-writes the class, therefore the request body must include all fields required to create (POST) a class. This is especially useful when updating a lot of information in the class at once.
+      - Mixins (deprecated)
+      summary: Update a custom mixin
+      description: "**NOTE**: This endpoint is deprecated. For future implementations,\
+        \ please use the [equivalent operation](#operation/updateFieldGroup) for the\
+        \ field groups endpoint instead."
+      operationId: replaceMixin
+      parameters:
+      - name: MIXIN_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the mixin in question.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: "The JSON payload must include all of the fields that were originally\
+          \ required for creating the field group, but with updated values. This includes\
+          \ an `allOf` attribute referencing the `$id` of the class the schema will\
+          \ implement."
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/replaceFieldGroup'
+        required: true
+      responses:
+        "200":
+          description: A successful response returns the details of the updated mixin.
+          content: {}
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      deprecated: true
+      x-codegen-request-body-name: body
+    delete:
+      tags:
+      - Mixins (deprecated)
+      summary: Delete a custom mixin
+      description: "**NOTE**: This endpoint is deprecated. For future implementations,\
+        \ please use the [equivalent operation](#operation/removeFieldGroup) for the\
+        \ field groups endpoint instead."
+      operationId: removeMixin
+      parameters:
+      - name: MIXIN_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the mixin in question.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: "A successful response returns an empty response body and HTTP\
+            \ status 204 (No Content), indicating that the mixin has been deleted."
+          content: {}
+        "404":
+          description: The resource is not found.
+          content: {}
+        "500":
+          description: An internal server error occurred.
+          content: {}
+      deprecated: true
+    patch:
+      tags:
+      - Mixins (deprecated)
+      summary: Update custom mixin
+      description: "**NOTE**: This endpoint is deprecated. For future implementations,\
+        \ please use the [equivalent operation](#operation/patchFieldGroup) for the\
+        \ field groups endpoint instead."
+      operationId: updateMixin
+      parameters:
+      - name: MIXIN_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the mixin in question.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: The request body accepts a JSON Patch payload.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/patchFieldGroup'
+        required: true
+      responses:
+        "200":
+          description: A successful response returns the details of the updated mixin.
+          content: {}
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      deprecated: true
+      x-codegen-request-body-name: body
+  /{CONTAINER_ID}/classes:
+    get:
+      tags:
+      - Classes
+      summary: List classes
+      description: ">**NOTE**: For more information on using this operation, see the\
+        \ [classes endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/classes.html)\
+        \ on Experience League."
+      operationId: listClasses
+      parameters:
+      - name: CONTAINER_ID
+        in: path
+        description: "The name of the container that you want to list resources from.\
+          \ To list core resources provided by Adobe, use `global`. To list custom\
+          \ resources defined by your organization, use `tenant`."
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: "The desired response format. For listing calls, the following\
+          \ `Accept` header values are permitted: \n<table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed-id+json</code></td><td>Returns\
+          \ a short summary of each resource, generally the preferred header for listing.</td></tr><tr><td><code>application/vnd.adobe.xed+json</code></td><td>Returns\
+          \ full JSON for each resource, with the original <code>$ref</code> and <code>allOf</code>\
+          \ attributes included.</td></tr></tbody></table>"
+        required: true
+        schema:
+          type: string
+      - name: property
+        in: query
+        description: "A comma-separated list of top-level object properties to be\
+          \ returned in the response. For example, `property=meta:intendedToExtend==https://ns.adobe.com/xdm/context/profile`\
+          \ returns only field groups that are compatible with the XDM Individual\
+          \ Profile class."
+        schema:
+          type: string
+      - name: orderby
+        in: query
+        description: "Sort the listed resources by specified fields. For example `orderby=title`\
+          \ sorts results by title in ascending order (A-Z). Adding a `-` before the\
+          \ field name (`orderby=-title`) sorts items in descending order (Z-A). Multiple\
+          \ fields can also be included to denote primary and secondary sort orders\
+          \ (for example, `orderby=title,description`)."
+        schema:
+          type: string
+      - name: start
+        in: query
+        description: |-
+          When used in conjunction with an `orderby` parameter, `start` specifies where the paginated list of items should begin. This parameter cannot be used without an `orderby` parameter present.
 
+          Typically, this parameter is omitted in order to obtain the first page of results. After that, `start` should be set to the maximum value of the primary sort property of the `orderby` field received in the previous page. The API response then returns entries beginning with those that have a primary sort property from `orderby` strictly greater than (for ascending) or strictly less than (for descending) the specified value.
+
+          For example, if the `orderby` parameter is set to `orderby=name,firstname`, the `start` parameter would contain a value for the `name` property. In this case, if you wanted to show the next 20 entries of a resource immediately following the name "Miller", you would use: `?orderby=name,firstname&start=Miller&limit=20`.
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: |-
+          When used in conjunction with an `orderby` parameter, `limit` restricts the maximum number of items that should be returned for a given request. This parameter cannot be used without an `orderby` parameter present.
+
+          The `limit` parameter specifies a positive integer (between `0` and `500`) as a *hint* as to the maximum number of items that should be returned. For example, `limit=5` returns only five resources in the list. However, this value is not strictly honored. The actual response size may be smaller or larger as constrained by the need to provide the reliable operation of the `start` parameter, if one is provided.
+        schema:
+          type: number
+      responses:
+        "200":
+          description: A successful response returns a list of all classes in the
+            container.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/listClassesResponse'
+        "400":
+          description: The `Accept` header is invalid or missing. Ensure that you
+            are providing a valid `Accept` header for a listing call with no version
+            supplied (e.g. `application/vnd.adobe.xed-id+json`) before trying again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/acceptErrorList'
+  /{CONTAINER_ID}/classes/{CLASS_ID}:
+    get:
+      tags:
+      - Classes
+      summary: Retrieve a class
+      description: ">**NOTE**: For more information on using this operation, see the\
+        \ [classes endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/classes.html)\
+        \ on Experience League."
+      operationId: retrieveClass
+      parameters:
+      - name: CONTAINER_ID
+        in: path
+        description: "The name of the container that you want to retrieve a resource\
+          \ from. To retrieve a core resource provided by Adobe, use `global`. To\
+          \ retrieve a custom resource defined by your organization, use `tenant`."
+        required: true
+        schema:
+          type: string
+      - name: CLASS_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the class you want to
+          look up.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: |-
+          The desired response format. For lookup requests, a `version` parameter must be included, with the following `Accept` header values being permitted:
+          <table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed+json; version=1</code></td><td>Returns only the basic details of the resource, with all inherited fields relegated to <code>$ref</code> and <code>allOf</code> properties.</td></tr><tr><td><code>application/vnd.adobe.xed-full+json; version=1</code></td><td>Returns the full details of the resource, including the details all fields inherited from other resources.</td></tr><tr><td><code>application/vnd.adobe.xed-notext+json; version=1</code></td><td>Returns only the basic details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-notext+json; version=1</code></td><td>Returns the full details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-desc+json; version=1</code></td><td>Returns the full details of the resource, including descriptions but with no titles.</td></tr></tbody></table>
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: A successful response returns the details of the class.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/lookupClassResponse'
+        "400":
+          description: "The `Accept` header is invalid or missing. Ensure that you\
+            \ are providing a valid `Accept` header for a single lookup call, including\
+            \ a major version (e.g. `application/vnd.adobe.xed-id+json; version=1`)\
+            \ before trying again."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/acceptErrorLookup'
+        "404":
+          description: The resource is not found.
+          content: {}
+  /tenant/classes:
+    post:
+      tags:
+      - Classes
+      summary: Create a custom class
+      description: ">**NOTE**: For more information on using this operation, see the\
+        \ [classes endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/classes.html)\
+        \ on Experience League."
+      operationId: createClass
+      parameters:
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: The request payload must include an `allOf` attribute referencing
+          either 'https://ns.adobe.com/xdm/data/record' or 'https://ns.adobe.com/xdm/data/time-series'.
+          This value represents the data behavior upon which the class is based. `allOf`
+          may also optionally include field groups or custom fields that will be included
+          each time the class is used.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/createClass'
+        required: true
+      responses:
+        "201":
+          description: A successful response returns the details of the newly created
+            class.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/createClassResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      x-codegen-request-body-name: body
+  /tenant/classes/{CLASS_ID}:
+    put:
+      tags:
+      - Classes
+      summary: Update a custom class
+      description: |-
+        A PUT request essentially re-writes the class, therefore the request body must include all fields required to create (POST) a class. This is especially useful when updating a lot of information in the class at once.
 
         >**NOTE**: For more information on using this operation, see the [classes endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/classes.html) on Experience League.
       operationId: replaceClass
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
-        - name: CLASS_ID
-          description: The `meta:altId` or URL-encoded `$id` of the class you want to update.
-          required: true
-          in: path
+      - name: CLASS_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the class you want to
+          update.
+        required: true
+        schema:
           type: string
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'
-        - $ref: '#/parameters/replaceClassPayload'
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: "The JSON payload must include all of the fields that were originally\
+          \ required for creating the class, but with updated values. This includes\
+          \ an `allOf` attribute referencing the behavior of the class."
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/replaceClass'
+        required: true
       responses:
-        '200':
+        "200":
           description: A successful response returns the details of the updated class.
-          schema:
-            $ref: '#/definitions/updateClassResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
-    patch:
-      tags:
-      - "Classes"
-      summary: Update one or more attributes of a custom class
-      description: >-
-        You can use this endpoint to update one or more attributes for a custom class.
-
-        The Schema Registry supports all standard JSON Patch operations, including `add`, `remove`, and `replace`, to allow users to modify or update classes they have defined.
-        
-        >**NOTE**: For more information on JSON Patch, including all available operations, please refer to the [the official JSON Patch specification](https://datatracker.ietf.org/doc/html/rfc6902).
-        >
-        >For more information on using this operation, see the [classes endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/classes.html) on Experience League.
-      operationId: updateClass
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - name: CLASS_ID
-          description: The `meta:altId` or URL-encoded `$id` of the class you want to update.
-          required: true
-          in: path
-          type: string
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'
-        - $ref: '#/parameters/patchClassPayload'
-      responses:
-        '200':
-          description: A successful response returns the the details of the updated class.
-          schema:
-            $ref: '#/definitions/patchClassResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/updateClassResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      x-codegen-request-body-name: body
     delete:
       tags:
-      - "Classes"
+      - Classes
       summary: Delete a custom class
-      description: >-
+      description: |-
         Remove a class by performing a DELETE request to the `$id` of the class being removed.
-        
-        
-        A successful deletion returns an empty response body and HTTP status 204 (No Content).
 
+        A successful deletion returns an empty response body and HTTP status 204 (No Content).
 
         >**NOTE**: For more information on using this operation, see the [classes endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/classes.html) on Experience League.
       operationId: removeClass
       parameters:
-        - name: CLASS_ID
-          description: The `meta:altId` or URL-encoded `$id` of the class you want to delete.
-          required: true
-          in: path
+      - name: CLASS_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the class you want to
+          delete.
+        required: true
+        schema:
           type: string
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
       responses:
-        '204':
-          description: A successful response returns an empty response body and HTTP status 204 (No Content), indicating that the resource has been deleted.
-        '404':
+        "204":
+          description: "A successful response returns an empty response body and HTTP\
+            \ status 204 (No Content), indicating that the resource has been deleted."
+          content: {}
+        "404":
           description: The resource is not found.
-  '/{CONTAINER_ID}/datatypes':
+          content: {}
+    patch:
+      tags:
+      - Classes
+      summary: Update one or more attributes of a custom class
+      description: |-
+        You can use this endpoint to update one or more attributes for a custom class.
+        The Schema Registry supports all standard JSON Patch operations, including `add`, `remove`, and `replace`, to allow users to modify or update classes they have defined.
+        >**NOTE**: For more information on JSON Patch, including all available operations, please refer to the [the official JSON Patch specification](https://datatracker.ietf.org/doc/html/rfc6902). > >For more information on using this operation, see the [classes endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/classes.html) on Experience League.
+      operationId: updateClass
+      parameters:
+      - name: CLASS_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the class you want to
+          update.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: The request body accepts a JSON Patch payload.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/patchClass'
+        required: true
+      responses:
+        "200":
+          description: A successful response returns the the details of the updated
+            class.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/patchClassResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      x-codegen-request-body-name: body
+  /{CONTAINER_ID}/datatypes:
     get:
       tags:
-      - "Data types"
+      - Data types
       summary: List data types
-      description: >-
-        >**NOTE**: For more information on using this operation, see the [data types endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/data-types.html) on Experience League.
+      description: ">**NOTE**: For more information on using this operation, see the\
+        \ [data types endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/data-types.html)\
+        \ on Experience League."
       operationId: listDataTypes
-      produces:
-        - application/json
       parameters:
-        - $ref: '#/parameters/containerIdList'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/acceptListing'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/property'
-        - $ref: '#/parameters/orderBy'
-        - $ref: '#/parameters/start'
-        - $ref: '#/parameters/limit'
+      - name: CONTAINER_ID
+        in: path
+        description: "The name of the container that you want to list resources from.\
+          \ To list core resources provided by Adobe, use `global`. To list custom\
+          \ resources defined by your organization, use `tenant`."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: "The desired response format. For listing calls, the following\
+          \ `Accept` header values are permitted: \n<table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed-id+json</code></td><td>Returns\
+          \ a short summary of each resource, generally the preferred header for listing.</td></tr><tr><td><code>application/vnd.adobe.xed+json</code></td><td>Returns\
+          \ full JSON for each resource, with the original <code>$ref</code> and <code>allOf</code>\
+          \ attributes included.</td></tr></tbody></table>"
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: property
+        in: query
+        description: "A comma-separated list of top-level object properties to be\
+          \ returned in the response. For example, `property=meta:intendedToExtend==https://ns.adobe.com/xdm/context/profile`\
+          \ returns only field groups that are compatible with the XDM Individual\
+          \ Profile class."
+        schema:
+          type: string
+      - name: orderby
+        in: query
+        description: "Sort the listed resources by specified fields. For example `orderby=title`\
+          \ sorts results by title in ascending order (A-Z). Adding a `-` before the\
+          \ field name (`orderby=-title`) sorts items in descending order (Z-A). Multiple\
+          \ fields can also be included to denote primary and secondary sort orders\
+          \ (for example, `orderby=title,description`)."
+        schema:
+          type: string
+      - name: start
+        in: query
+        description: |-
+          When used in conjunction with an `orderby` parameter, `start` specifies where the paginated list of items should begin. This parameter cannot be used without an `orderby` parameter present.
+
+          Typically, this parameter is omitted in order to obtain the first page of results. After that, `start` should be set to the maximum value of the primary sort property of the `orderby` field received in the previous page. The API response then returns entries beginning with those that have a primary sort property from `orderby` strictly greater than (for ascending) or strictly less than (for descending) the specified value.
+
+          For example, if the `orderby` parameter is set to `orderby=name,firstname`, the `start` parameter would contain a value for the `name` property. In this case, if you wanted to show the next 20 entries of a resource immediately following the name "Miller", you would use: `?orderby=name,firstname&start=Miller&limit=20`.
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: |-
+          When used in conjunction with an `orderby` parameter, `limit` restricts the maximum number of items that should be returned for a given request. This parameter cannot be used without an `orderby` parameter present.
+
+          The `limit` parameter specifies a positive integer (between `0` and `500`) as a *hint* as to the maximum number of items that should be returned. For example, `limit=5` returns only five resources in the list. However, this value is not strictly honored. The actual response size may be smaller or larger as constrained by the need to provide the reliable operation of the `start` parameter, if one is provided.
+        schema:
+          type: number
       responses:
-        '200':
-          description: A successful response returns a list of all data types in the specified container.
-          schema:
-            $ref: '#/definitions/listDataTypesResponse'
-        '400':
-          description: The `Accept` header is invalid or missing. Ensure that you are providing a valid `Accept` header for a listing call with no version supplied (e.g. `application/vnd.adobe.xed-id+json`) before trying again.
-          schema:
-           $ref: '#/definitions/acceptErrorList' 
-        
-  '/{CONTAINER_ID}/datatypes/{DATA_TYPE_ID}':
+        "200":
+          description: A successful response returns a list of all data types in the
+            specified container.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/listDataTypesResponse'
+        "400":
+          description: The `Accept` header is invalid or missing. Ensure that you
+            are providing a valid `Accept` header for a listing call with no version
+            supplied (e.g. `application/vnd.adobe.xed-id+json`) before trying again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/acceptErrorList'
+  /{CONTAINER_ID}/datatypes/{DATA_TYPE_ID}:
     get:
       tags:
-      - "Data types"
-      parameters:
-        - $ref: '#/parameters/containerIdLookup'
-        - $ref: '#/parameters/DATA_TYPE_ID'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/accept'
+      - Data types
       summary: Retrieve a data type
-      description: >-
-        >**NOTE**: For more information on using this operation, see the [data types endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/data-types.html) on Experience League.
+      description: ">**NOTE**: For more information on using this operation, see the\
+        \ [data types endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/data-types.html)\
+        \ on Experience League."
       operationId: retrieveDataType
-      produces:
-        - application/json
+      parameters:
+      - name: CONTAINER_ID
+        in: path
+        description: "The name of the container that you want to retrieve a resource\
+          \ from. To retrieve a core resource provided by Adobe, use `global`. To\
+          \ retrieve a custom resource defined by your organization, use `tenant`."
+        required: true
+        schema:
+          type: string
+      - name: DATA_TYPE_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the data type in question.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: |-
+          The desired response format. For lookup requests, a `version` parameter must be included, with the following `Accept` header values being permitted:
+          <table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed+json; version=1</code></td><td>Returns only the basic details of the resource, with all inherited fields relegated to <code>$ref</code> and <code>allOf</code> properties.</td></tr><tr><td><code>application/vnd.adobe.xed-full+json; version=1</code></td><td>Returns the full details of the resource, including the details all fields inherited from other resources.</td></tr><tr><td><code>application/vnd.adobe.xed-notext+json; version=1</code></td><td>Returns only the basic details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-notext+json; version=1</code></td><td>Returns the full details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-desc+json; version=1</code></td><td>Returns the full details of the resource, including descriptions but with no titles.</td></tr></tbody></table>
+        required: true
+        schema:
+          type: string
       responses:
-        '200':
+        "200":
           description: A successful response returns the details of the data type.
-          schema:
-            $ref: '#/definitions/lookupDataTypeResponse'
-        '400':
-          description: The `Accept` header is invalid or missing. Ensure that you are providing a valid accept header for a lookup call including a version number (e.g. `application/vnd.adobe.xed+json;version=1`) before trying again.
-          schema:
-            $ref: '#/definitions/acceptErrorLookup'
-        
-  '/tenant/datatypes':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/lookupDataTypeResponse'
+        "400":
+          description: The `Accept` header is invalid or missing. Ensure that you
+            are providing a valid accept header for a lookup call including a version
+            number (e.g. `application/vnd.adobe.xed+json;version=1`) before trying
+            again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/acceptErrorLookup'
+  /tenant/datatypes:
     post:
       tags:
-      - "Data types"
+      - Data types
       summary: Create a custom data type
-      description: >-
-        >**NOTE**: For more information on using this operation, see the [data types endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/data-types.html) on Experience League.
+      description: ">**NOTE**: For more information on using this operation, see the\
+        \ [data types endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/data-types.html)\
+        \ on Experience League."
       operationId: createDataType
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/accept'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/content-type'
-        - $ref: '#/parameters/createDataTypePayload'
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: |-
+          The desired response format. For lookup requests, a `version` parameter must be included, with the following `Accept` header values being permitted:
+          <table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed+json; version=1</code></td><td>Returns only the basic details of the resource, with all inherited fields relegated to <code>$ref</code> and <code>allOf</code> properties.</td></tr><tr><td><code>application/vnd.adobe.xed-full+json; version=1</code></td><td>Returns the full details of the resource, including the details all fields inherited from other resources.</td></tr><tr><td><code>application/vnd.adobe.xed-notext+json; version=1</code></td><td>Returns only the basic details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-notext+json; version=1</code></td><td>Returns the full details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-desc+json; version=1</code></td><td>Returns the full details of the resource, including descriptions but with no titles.</td></tr></tbody></table>
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: |-
+          Unlike field groups, defining a data type does not require `meta:extends` or `meta:intendedToExtend` fields, nor do fields need to be nested to avoid collisions.
+          When it comes to defining the field structure of data type itself, you can use primitive types (like `string` or `object`) or you can reference other existing data types through `$ref` attributes. See the guide on [defining custom XDM fields in the API](../tutorials/custom-fields-api.md) for detailed guidance on the expected format for different XDM field types.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/createDataType'
+        required: true
       responses:
-        '201':
-          description: A successful response returns the details of the newly created data type.
-          schema: 
-            '$ref': '#/definitions/createDataTypeResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
-  '/tenant/datatypes/{DATA_TYPE_ID}':
+        "201":
+          description: A successful response returns the details of the newly created
+            data type.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/createDataTypeResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      x-codegen-request-body-name: body
+  /tenant/datatypes/{DATA_TYPE_ID}:
     put:
       tags:
-      - "Data types"
+      - Data types
       summary: Update a custom data type
-      description: >-
+      description: |-
         A PUT request essentially re-writes the data type, therefore the request body must include all fields required to create (POST) a data type. This is especially useful when updating a lot of information in the data type at once.
-
 
         >**NOTE**: For more information on using this operation, see the [data types endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/data-types.html) on Experience League.
       operationId: replaceDatatype
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
-        - $ref: '#/parameters/DATA_TYPE_ID'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'
-        - $ref: '#/parameters/replaceDataTypePayload'
+      - name: DATA_TYPE_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the data type in question.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: "The JSON payload must include all of the fields that were originally\
+          \ required for creating the data type, but with updated values."
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/replaceDataType'
+        required: true
       responses:
-        '200':
-          description: A successful response returns the details of the updated data type.
-          schema: 
-            '$ref': '#/definitions/putDataTypeResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
-    patch:
-      tags:
-      - "Data types"
-      summary: Update a custom data type's attributes
-      operationId: updateDataType
-      description: >-
-        You can use this endpoint to update one or more attributes of a custom data type.
-      
-        The Schema Registry supports all standard JSON Patch operations, including `add`, `remove`, and `replace`, to allow users to modify or update data types they have defined.
-        
-        
-        >**NOTE**: For more information on JSON Patch, including all available operations, please refer to the [the official JSON Patch specification](https://datatracker.ietf.org/doc/html/rfc6902).
-        >
-        >For more information on using this operation, see the [data types endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/data-types.html) on Experience League.
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: '#/parameters/DATA_TYPE_ID'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/content-type'
-        - $ref: '#/parameters/patchDataTypePayload'
-      responses:
-        '200':
-          description: A successful response returns the details of the updated data type.
-          schema: 
-            '$ref': '#/definitions/patchDataTypeResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
+        "200":
+          description: A successful response returns the details of the updated data
+            type.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/putDataTypeResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      x-codegen-request-body-name: body
     delete:
       tags:
-      - "Data types"
+      - Data types
       summary: Delete a custom class
-      description: >-
+      description: |-
         Removing a data type is done through a DELETE request to the `$id` of the data type being removed.
-        
-        
-        A successful deletion returns an empty response body and HTTP status 204 (No Content).
 
+        A successful deletion returns an empty response body and HTTP status 204 (No Content).
 
         >**NOTE**: For more information on using this operation, see the [data types endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/data-types.html) on Experience League.
       operationId: deleteDatatype
       parameters:
-        - $ref: '#/parameters/DATA_TYPE_ID'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
+      - name: DATA_TYPE_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the data type in question.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
       responses:
-        '204':
-          description: A successful response returns an empty response body and HTTP status 204 (No Content), indicating that the class has been deleted.
-        '404':
+        "204":
+          description: "A successful response returns an empty response body and HTTP\
+            \ status 204 (No Content), indicating that the class has been deleted."
+          content: {}
+        "404":
           description: The resource is not found.
-        '500':
-         description: An internal server error occurred.
-  '/{CONTAINER_ID}/descriptors':
+          content: {}
+        "500":
+          description: An internal server error occurred.
+          content: {}
+    patch:
+      tags:
+      - Data types
+      summary: Update a custom data type's attributes
+      description: |-
+        You can use this endpoint to update one or more attributes of a custom data type.
+        The Schema Registry supports all standard JSON Patch operations, including `add`, `remove`, and `replace`, to allow users to modify or update data types they have defined.
+
+        >**NOTE**: For more information on JSON Patch, including all available operations, please refer to the [the official JSON Patch specification](https://datatracker.ietf.org/doc/html/rfc6902). > >For more information on using this operation, see the [data types endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/data-types.html) on Experience League.
+      operationId: updateDataType
+      parameters:
+      - name: DATA_TYPE_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the data type in question.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: The request body accepts a JSON Patch payload.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/patchDataType'
+        required: true
+      responses:
+        "200":
+          description: A successful response returns the details of the updated data
+            type.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/patchDataTypeResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      x-codegen-request-body-name: body
+  /{CONTAINER_ID}/descriptors:
     get:
       tags:
-      - "Descriptors"
+      - Descriptors
       summary: List descriptors
-      description: >-
+      description: |-
         Schemas define a static view of data entities, but do not provide specific details on how data based on these schemas (datasets) may relate to one another. Platform allows you to describe these relationships and other interpretive metadata about a schema through the use of descriptors.
-        
-        
-        Descriptors are tenant-level metadata for schemas, meaning they are unique to your IMS Organization and all descriptor operations take place in the `tenant` container.
-        
-        
-        Each schema can have one or more schema descriptor entities applied to it. Each schema descriptor entity includes a descriptor `@type` and the `sourceSchema` to which it applies. Once applied, these descriptors apply to all datasets created using the schema.
 
+        Descriptors are tenant-level metadata for schemas, meaning they are unique to your IMS Organization and all descriptor operations take place in the `tenant` container.
+
+        Each schema can have one or more schema descriptor entities applied to it. Each schema descriptor entity includes a descriptor `@type` and the `sourceSchema` to which it applies. Once applied, these descriptors apply to all datasets created using the schema.
 
         >**NOTE**: For more information on using this operation, see the [descriptors endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/descriptors.html) on Experience League.
       operationId: listDescriptors
-      produces:
-      - application/json
       parameters:
-      - $ref: '#/parameters/containerIdList'
-      - $ref: '#/parameters/authorization'
-      - $ref: '#/parameters/x-api-key'
-      - $ref: '#/parameters/x-gw-ims-org-id'
-      - $ref: '#/parameters/x-sandbox-name'
-      - $ref: '#/parameters/acceptDescriptors'
-      - $ref: '#/parameters/property'
+      - name: CONTAINER_ID
+        in: path
+        description: "The name of the container that you want to list resources from.\
+          \ To list core resources provided by Adobe, use `global`. To list custom\
+          \ resources defined by your organization, use `tenant`."
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: |-
+          The desired response format. Descriptors require unique `Accept` headers using `xdm` instead of `xed`. The following values are permitted:
+          <table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xdm-id+json</code></td><td>Returns a list of descriptor IDs, grouped by their <code>@type</code>.</td></tr><tr><td><code>application/vnd.adobe.xdm-link+json</code></td><td>Returns a list of descriptor API paths, grouped by their <code>@type</code>.</td></tr><tr><td><code>application/vnd.adobe.xdm+json</code></td><td>Returns a list of descriptor objects, grouped by their <code>@type</code>.</td></tr><tr><td><code>application/vnd.adobe.xdm-v2{-id/-link}+json</code></td><td>Including the <code>-v2</code> option in any of the above <code>Accept</code> headers permits paging functionality, returning a results array with a <code>_page</code> attribute that can be used to request the next page if needed.</td></tr></tbody></table>
+        required: true
+        schema:
+          type: string
+      - name: property
+        in: query
+        description: "A comma-separated list of top-level object properties to be\
+          \ returned in the response. For example, `property=meta:intendedToExtend==https://ns.adobe.com/xdm/context/profile`\
+          \ returns only field groups that are compatible with the XDM Individual\
+          \ Profile class."
+        schema:
+          type: string
       - name: orderby
-        description: Sort response by specified fields separated by "," and/or prefix field with "-" for descending order. Used by the v2 option of the API, as indicated by the `Accept` header.
-        required: false
         in: query
-        type: string
+        description: "Sort response by specified fields separated by \",\" and/or\
+          \ prefix field with \"-\" for descending order. Used by the v2 option of\
+          \ the API, as indicated by the `Accept` header."
+        schema:
+          type: string
       - name: limit
-        description: Specify a limit for the number of response results to be displayed (must be between 0 and 500). Used by the v2 option of the API, as indicated by the `Accept` header.
-        required: false
         in: query
-        type: number
+        description: "Specify a limit for the number of response results to be displayed\
+          \ (must be between 0 and 500). Used by the v2 option of the API, as indicated\
+          \ by the `Accept` header."
+        schema:
+          type: number
       - name: start
-        description: The start value of the first `orderBy` field. The value of this parameter be the same data type as that of the `orderBy` field (e.g. strings or integers). Used by the v2 option of the API, as indicated by the `Accept` header.
-        required: false
         in: query
-        type: string
+        description: "The start value of the first `orderBy` field. The value of this\
+          \ parameter be the same data type as that of the `orderBy` field (e.g. strings\
+          \ or integers). Used by the v2 option of the API, as indicated by the `Accept`\
+          \ header."
+        schema:
+          type: string
       responses:
-        '200':
-          description: A successful response returns a list of all existing descriptors, separated by type.
-          schema:
-            $ref: '#/definitions/listDescriptorsResponse'
-        '400':
-          description: The `Accept` header is invalid or missing. Ensure that you are providing a valid `Accept` header for the descriptors endpoint with no version supplied (e.g. `application/vnd.adobe.xdm+json`) before trying again.
-          schema:
-           $ref: '#/definitions/acceptErrorDescriptorList' 
-        
-  '/{CONTAINER_ID}/descriptors/{DESCRIPTOR_ID}':
+        "200":
+          description: "A successful response returns a list of all existing descriptors,\
+            \ separated by type."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/listDescriptorsResponse'
+        "400":
+          description: The `Accept` header is invalid or missing. Ensure that you
+            are providing a valid `Accept` header for the descriptors endpoint with
+            no version supplied (e.g. `application/vnd.adobe.xdm+json`) before trying
+            again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/acceptErrorDescriptorList'
+  /{CONTAINER_ID}/descriptors/{DESCRIPTOR_ID}:
     get:
       tags:
-      - "Descriptors"
+      - Descriptors
       summary: Retrieve a descriptor
-      description: >-
+      description: |-
         View the details of a specific descriptor by performing a lookup (GET) request using the `@id` of the descriptor. Descriptors are not versioned, therefore no `Accept` header is required in the lookup request.
-
 
         >**NOTE**: For more information on using this operation, see the [descriptors endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/descriptors.html) on Experience League.
       operationId: retrieveDescriptor
-      produces:
-      - application/json
       parameters:
-      - $ref: '#/parameters/containerIdLookup'
-      - $ref: '#/parameters/DESCRIPTOR_ID'
-      - $ref: '#/parameters/authorization'
-      - $ref: '#/parameters/x-api-key'
-      - $ref: '#/parameters/x-gw-ims-org-id'
-      - $ref: '#/parameters/x-sandbox-name'
+      - name: CONTAINER_ID
+        in: path
+        description: "The name of the container that you want to retrieve a resource\
+          \ from. To retrieve a core resource provided by Adobe, use `global`. To\
+          \ retrieve a custom resource defined by your organization, use `tenant`."
+        required: true
+        schema:
+          type: string
+      - name: DESCRIPTOR_ID
+        in: path
+        description: The unique ID (`@id`) of the descriptor in question.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
       responses:
-        '200':
+        "200":
           description: A successful response returns the details of the descriptor.
-          schema:
-            $ref: '#/definitions/identityDescriptorResponse'
-        '400':
-          description: The `Accept` header is invalid or missing. Ensure that you are providing a valid `Accept` header for the descriptors endpoint with no version supplied (e.g. `application/vnd.adobe.xdm+json`) before trying again.
-          schema:
-           $ref: '#/definitions/acceptErrorDescriptorLookup' 
-        
-  '/tenant/descriptors':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/identityDescriptorResponse'
+        "400":
+          description: The `Accept` header is invalid or missing. Ensure that you
+            are providing a valid `Accept` header for the descriptors endpoint with
+            no version supplied (e.g. `application/vnd.adobe.xdm+json`) before trying
+            again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/acceptErrorDescriptorLookup'
+  /tenant/descriptors:
     post:
       tags:
-      - "Descriptors"
+      - Descriptors
       summary: Create a descriptor
-      description: >-
-        You can create a new descriptor by making a POST request. The required request payload fields vary based on the `@type` of descriptor being defined. For details on the requirements for each descriptor type, refer to the section on [defining descriptors](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/descriptors.html#defining-descriptors) on Experience League.
+      description: "You can create a new descriptor by making a POST request. The\
+        \ required request payload fields vary based on the `@type` of descriptor\
+        \ being defined. For details on the requirements for each descriptor type,\
+        \ refer to the section on [defining descriptors](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/descriptors.html#defining-descriptors)\
+        \ on Experience League."
       operationId: createDescriptor
-      consumes:
-      - application/json
-      produces:
-      - application/json
       parameters:
-      - $ref: '#/parameters/authorization'
-      - $ref: '#/parameters/x-api-key'
-      - $ref: '#/parameters/x-gw-ims-org-id'
-      - $ref: '#/parameters/x-sandbox-name'
-      - $ref: '#/parameters/content-type'
-      - $ref: '#/parameters/descriptorPayload'
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: "The required request payload fields vary based on the `@type`\
+          \ of descriptor being defined. For details on the requirements for each\
+          \ descriptor type, refer to the section on [defining descriptors](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/descriptors.html?lang=en#defining-descriptors)\
+          \ in the API guide."
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/createDescriptor'
+        required: true
       responses:
-        '201':
-          description: A successful response returns the details of the newly created descriptor.
-          schema:
-            $ref: '#/definitions/createDescriptorResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
-  
-  '/tenant/descriptors/{DESCRIPTOR_ID}':
+        "201":
+          description: A successful response returns the details of the newly created
+            descriptor.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/createDescriptorResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      x-codegen-request-body-name: body
+  /tenant/descriptors/{DESCRIPTOR_ID}:
     put:
       tags:
-      - "Descriptors"
+      - Descriptors
       summary: Update a descriptor
-      description: >-
+      description: |-
         You can update a descriptor by making a PUT request. This action essentially rewrites the existing descriptor, therefore the payload must include all fields that were required when the descriptor was first defined.
-
 
         >**NOTE**: For more information on using this operation, see the [descriptors endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/descriptors.html) on Experience League.
       operationId: updateDescriptor
-      consumes:
-      - application/json
-      produces:
-      - application/json
       parameters:
-      - $ref: '#/parameters/DESCRIPTOR_ID'
-      - $ref: '#/parameters/authorization'
-      - $ref: '#/parameters/x-api-key'
-      - $ref: '#/parameters/x-gw-ims-org-id'
-      - $ref: '#/parameters/x-sandbox-name'
-      - $ref: '#/parameters/content-type'
-      - $ref: '#/parameters/descriptorPayload'
+      - name: DESCRIPTOR_ID
+        in: path
+        description: The unique ID (`@id`) of the descriptor in question.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Content-Type
+        in: header
+        description: "The type of content being sent in the body of the request. When\
+          \ sending requests that include payloads to the Schema Registry API, this\
+          \ header must be included with a value of `application/json`."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: "The required request payload fields vary based on the `@type`\
+          \ of descriptor being defined. For details on the requirements for each\
+          \ descriptor type, refer to the section on [defining descriptors](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/descriptors.html?lang=en#defining-descriptors)\
+          \ in the API guide."
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/createDescriptor'
+        required: true
       responses:
-        '200':
+        "200":
           description: A successful response returns the details of the updated descriptor.
-          schema:
-            $ref: '#/definitions/createDescriptorResponse'
-        '400':
-          description: The request payload was incorrectly formatted. Check your payload formatting before trying again.
-        
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/createDescriptorResponse'
+        "400":
+          description: The request payload was incorrectly formatted. Check your payload
+            formatting before trying again.
+          content: {}
+      x-codegen-request-body-name: body
     delete:
       tags:
-      - "Descriptors"
+      - Descriptors
       summary: Delete a descriptor
-      description: >-
-        >**NOTE**: For more information on using this operation, see the [descriptors endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/descriptors.html) on Experience League.
+      description: ">**NOTE**: For more information on using this operation, see the\
+        \ [descriptors endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/descriptors.html)\
+        \ on Experience League."
       operationId: deleteDescriptor
       parameters:
-      - $ref: '#/parameters/DESCRIPTOR_ID'
-      - $ref: '#/parameters/authorization'
-      - $ref: '#/parameters/x-api-key'
-      - $ref: '#/parameters/x-gw-ims-org-id'
-      - $ref: '#/parameters/x-sandbox-name'
+      - name: DESCRIPTOR_ID
+        in: path
+        description: The unique ID (`@id`) of the descriptor in question.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
       responses:
-        '204':
-          description: A successful response returns an empty response body and HTTP status 204 (No Content), indicating that the descriptor has been deleted.
-        '403':
+        "204":
+          description: "A successful response returns an empty response body and HTTP\
+            \ status 204 (No Content), indicating that the descriptor has been deleted."
+          content: {}
+        "403":
           description: Forbidden
-        '404':
+          content: {}
+        "404":
           description: The resource is not found.
-        
-  '/tenant/unions':
+          content: {}
+  /tenant/unions:
     get:
       tags:
       - Unions
       summary: List union schemas
-      description: >-
-        >**NOTE**: For more information on using this operation, see the [unions endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/unions.html) on Experience League.
+      description: ">**NOTE**: For more information on using this operation, see the\
+        \ [unions endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/unions.html)\
+        \ on Experience League."
       operationId: listUnionSchemas
       parameters:
-        - $ref: '#/parameters/acceptListing'
-        - $ref: '#/parameters/authorization'
-        - $ref: '#/parameters/x-api-key'
-        - $ref: '#/parameters/x-gw-ims-org-id'
-        - $ref: '#/parameters/x-sandbox-name'
-        - $ref: '#/parameters/property'
-        - $ref: '#/parameters/orderBy'
-        - $ref: '#/parameters/start'
-        - $ref: '#/parameters/limit'
+      - name: Accept
+        in: header
+        description: "The desired response format. For listing calls, the following\
+          \ `Accept` header values are permitted: \n<table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed-id+json</code></td><td>Returns\
+          \ a short summary of each resource, generally the preferred header for listing.</td></tr><tr><td><code>application/vnd.adobe.xed+json</code></td><td>Returns\
+          \ full JSON for each resource, with the original <code>$ref</code> and <code>allOf</code>\
+          \ attributes included.</td></tr></tbody></table>"
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: property
+        in: query
+        description: "A comma-separated list of top-level object properties to be\
+          \ returned in the response. For example, `property=meta:intendedToExtend==https://ns.adobe.com/xdm/context/profile`\
+          \ returns only field groups that are compatible with the XDM Individual\
+          \ Profile class."
+        schema:
+          type: string
+      - name: orderby
+        in: query
+        description: "Sort the listed resources by specified fields. For example `orderby=title`\
+          \ sorts results by title in ascending order (A-Z). Adding a `-` before the\
+          \ field name (`orderby=-title`) sorts items in descending order (Z-A). Multiple\
+          \ fields can also be included to denote primary and secondary sort orders\
+          \ (for example, `orderby=title,description`)."
+        schema:
+          type: string
+      - name: start
+        in: query
+        description: |-
+          When used in conjunction with an `orderby` parameter, `start` specifies where the paginated list of items should begin. This parameter cannot be used without an `orderby` parameter present.
+
+          Typically, this parameter is omitted in order to obtain the first page of results. After that, `start` should be set to the maximum value of the primary sort property of the `orderby` field received in the previous page. The API response then returns entries beginning with those that have a primary sort property from `orderby` strictly greater than (for ascending) or strictly less than (for descending) the specified value.
+
+          For example, if the `orderby` parameter is set to `orderby=name,firstname`, the `start` parameter would contain a value for the `name` property. In this case, if you wanted to show the next 20 entries of a resource immediately following the name "Miller", you would use: `?orderby=name,firstname&start=Miller&limit=20`.
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: |-
+          When used in conjunction with an `orderby` parameter, `limit` restricts the maximum number of items that should be returned for a given request. This parameter cannot be used without an `orderby` parameter present.
+
+          The `limit` parameter specifies a positive integer (between `0` and `500`) as a *hint* as to the maximum number of items that should be returned. For example, `limit=5` returns only five resources in the list. However, this value is not strictly honored. The actual response size may be smaller or larger as constrained by the need to provide the reliable operation of the `start` parameter, if one is provided.
+        schema:
+          type: number
       responses:
-        '200':
-          description: A successful response returns a list of all union schemas with format dependent on the `Accept` header.
-          schema:
-            $ref: '#/definitions/listUnionsResponse'
-        '400':
-          description: The `Accept` header is invalid or missing. Ensure that you are providing a valid `Accept` header for a listing call with no version supplied (e.g. `application/vnd.adobe.xed-id+json`) before trying again.
-          schema:
-           $ref: '#/definitions/acceptErrorList' 
-        
-  '/tenant/unions/{UNION_ID}':
+        "200":
+          description: A successful response returns a list of all union schemas with
+            format dependent on the `Accept` header.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/listUnionsResponse'
+        "400":
+          description: The `Accept` header is invalid or missing. Ensure that you
+            are providing a valid `Accept` header for a listing call with no version
+            supplied (e.g. `application/vnd.adobe.xed-id+json`) before trying again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/acceptErrorList'
+  /tenant/unions/{UNION_ID}:
     get:
       tags:
       - Unions
-      parameters:
-      - $ref: '#/parameters/UNION_ID'
-      - $ref: '#/parameters/authorization'
-      - $ref: '#/parameters/x-api-key'
-      - $ref: '#/parameters/x-gw-ims-org-id'
-      - $ref: '#/parameters/x-sandbox-name'
-      - $ref: '#/parameters/accept'
       summary: Retrieve a union schema
-      description: >-
-        >**NOTE**: For more information on using this operation, see the [unions endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/unions.html) on Experience League.
+      description: ">**NOTE**: For more information on using this operation, see the\
+        \ [unions endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/unions.html)\
+        \ on Experience League."
       operationId: retrieveUnionSchema
+      parameters:
+      - name: UNION_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` of the union schema in
+          question.
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: |-
+          The desired response format. For lookup requests, a `version` parameter must be included, with the following `Accept` header values being permitted:
+          <table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed+json; version=1</code></td><td>Returns only the basic details of the resource, with all inherited fields relegated to <code>$ref</code> and <code>allOf</code> properties.</td></tr><tr><td><code>application/vnd.adobe.xed-full+json; version=1</code></td><td>Returns the full details of the resource, including the details all fields inherited from other resources.</td></tr><tr><td><code>application/vnd.adobe.xed-notext+json; version=1</code></td><td>Returns only the basic details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-notext+json; version=1</code></td><td>Returns the full details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-desc+json; version=1</code></td><td>Returns the full details of the resource, including descriptions but with no titles.</td></tr></tbody></table>
+        required: true
+        schema:
+          type: string
       responses:
-        '200':
+        "200":
           description: A successful response returns the details of the union.
-          schema:
-            $ref: '#/definitions/lookupUnionResponse'
-        '400':
-          description: The `Accept` header is invalid or missing. Ensure that you are providing a valid accept header for a lookup call including a version number (e.g. `application/vnd.adobe.xed+json;version=1`) before trying again.
-          schema:
-            $ref: '#/definitions/acceptErrorLookup'
-        
-  '/rpc/export/{RESOURCE_ID}':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/lookupUnionResponse'
+        "400":
+          description: The `Accept` header is invalid or missing. Ensure that you
+            are providing a valid accept header for a lookup call including a version
+            number (e.g. `application/vnd.adobe.xed+json;version=1`) before trying
+            again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/acceptErrorLookup'
+  /rpc/export/{RESOURCE_ID}:
     get:
       tags:
-      - "Export/Import"
-      summary: Retrieve an export payload 
-      description: >-
+      - Export/Import
+      summary: Retrieve an export payload
+      description: |-
         You can use this endpoint to retrieve an export payload for a specific resource in order to transfer it into a different sandbox or IMS Organization.
-
 
         >**NOTE**: For more information on using this operation, see the [export](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/export.html) and [import endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/import.html) on Experience League.
       operationId: retrieveExportPayload
       parameters:
-      - $ref: '#/parameters/authorization'
-      - $ref: '#/parameters/x-api-key'
-      - $ref: '#/parameters/x-gw-ims-org-id'
-      - $ref: '#/parameters/x-sandbox-name'
-      - $ref: '#/parameters/accept'
-      - name: RESOURCE_ID
-        description: The `meta:altId` or URL-encoded `$id` value of the schema, field group, or data type you want to export.
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
         required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: |-
+          The desired response format. For lookup requests, a `version` parameter must be included, with the following `Accept` header values being permitted:
+          <table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed+json; version=1</code></td><td>Returns only the basic details of the resource, with all inherited fields relegated to <code>$ref</code> and <code>allOf</code> properties.</td></tr><tr><td><code>application/vnd.adobe.xed-full+json; version=1</code></td><td>Returns the full details of the resource, including the details all fields inherited from other resources.</td></tr><tr><td><code>application/vnd.adobe.xed-notext+json; version=1</code></td><td>Returns only the basic details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-notext+json; version=1</code></td><td>Returns the full details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-desc+json; version=1</code></td><td>Returns the full details of the resource, including descriptions but with no titles.</td></tr></tbody></table>
+        required: true
+        schema:
+          type: string
+      - name: RESOURCE_ID
         in: path
-        type: string
+        description: "The `meta:altId` or URL-encoded `$id` value of the schema, field\
+          \ group, or data type you want to export."
+        required: true
+        schema:
+          type: string
       responses:
-        '200':
-          description: A successful response returns the details of the exported resource and its dependent field groups and data types, with any tenant ID values being replaced with `<XDM_TENANTID_PLACEHOLDER>`. The contents of this payload can then be used as the request body in a POST `/rpc/import` call to import the resource to the desired sandbox or IMS Organization.
-          schema:
-            $ref: '#/definitions/importExportPayload'
-        '404':
-          description: No schema could be found for the specified {SCHEMA_ID}. Double-check that you are providing a valid {SCHEMA_ID} and are using the correct {IMS_ORG} and {SANDBOX_NAME} headers for that schema before trying again.
-          schema:
-            $ref: '#/definitions/notFoundError'
-  '/rpc/import':
+        "200":
+          description: "A successful response returns the details of the exported\
+            \ resource and its dependent field groups and data types, with any tenant\
+            \ ID values being replaced with `<XDM_TENANTID_PLACEHOLDER>`. The contents\
+            \ of this payload can then be used as the request body in a POST `/rpc/import`\
+            \ call to import the resource to the desired sandbox or IMS Organization."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/importExportPayload'
+        "404":
+          description: "No schema could be found for the specified {SCHEMA_ID}. Double-check\
+            \ that you are providing a valid {SCHEMA_ID} and are using the correct\
+            \ {IMS_ORG} and {SANDBOX_NAME} headers for that schema before trying again."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/notFoundError'
+  /rpc/import:
     post:
       tags:
-      - "Export/Import"
+      - Export/Import
       summary: Import a resource
-      description: >-
+      description: |-
         Use an export payload to import a resource into a different sandbox or IMS Organization.
-
 
         >**NOTE**: For more information on using this operation, see the [export/import endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/export-import.html) on Experience League.
       operationId: importResource
       parameters:
-      - $ref: '#/parameters/authorization'
-      - $ref: '#/parameters/x-api-key'
-      - name: x-gw-ims-org-id
-        required: true
+      - name: Authorization
         in: header
-        description: The unique ID ({IMS_ORG}) of the IMS Organization that you want to import the resource into.
-        type: string
-      - name: x-sandbox-name
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
         required: true
-        in: header
-        type: string
-        description: The name of the sandbox that you want to import the resource into. See the [sandboxes overview documentation](https://adobe.com/go/sandbox-overview-en) for more information.
-      - name: body
-        description: The payload returned by a GET `/rpc/export/{RESOURCE_ID}` call, indicating which schemas, field groups, and/or data types should be imported into the destination IMS Organization and sandbox.
-        in: body
         schema:
-          $ref: '#/definitions/importExportPayload'
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The unique ID ({IMS_ORG}) of the IMS Organization that you want\
+          \ to import the resource into."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox that you want to import the resource\
+          \ into. See the [sandboxes overview documentation](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: "The payload returned by a GET `/rpc/export/{RESOURCE_ID}` call,\
+          \ indicating which schemas, field groups, and/or data types should be imported\
+          \ into the destination IMS Organization and sandbox."
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/importExportPayload'
+        required: false
       responses:
-        '200':
-          description: A successful response returns the details of the imported resource, with the appropriate `{TENANT_ID}` applied for the specified IMS Organization.
-          schema:
-            $ref: '#/definitions/importResponse'
-        '400':
-          description: The resources failed to import due to a conflict. In order to import XDM resources, their `$id` and `title` values must be unique within the destination IMS Org and sandbox. The error message will indicate which field contains the conflicting value. Change this value in the request payload before attempting the import again.
-          schema:
-            $ref: '#/definitions/importError'
-  '/rpc/sampledata/{SCHEMA_ID}':
+        "200":
+          description: "A successful response returns the details of the imported\
+            \ resource, with the appropriate `{TENANT_ID}` applied for the specified\
+            \ IMS Organization."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/importResponse'
+        "400":
+          description: "The resources failed to import due to a conflict. In order\
+            \ to import XDM resources, their `$id` and `title` values must be unique\
+            \ within the destination IMS Org and sandbox. The error message will indicate\
+            \ which field contains the conflicting value. Change this value in the\
+            \ request payload before attempting the import again."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/importError'
+      x-codegen-request-body-name: body
+  /rpc/sampledata/{SCHEMA_ID}:
     get:
       tags:
-      - "Sample data"
+      - Sample data
       summary: Retrieve sample data
-      description: >-
+      description: |-
         Retrieve sample data for a schema.
-
         >**NOTE**: For more information on using this operation, see the [sample data endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/sample-data.html) on Experience League.
       operationId: retrieveSampleData
       parameters:
-      - $ref: '#/parameters/authorization'
-      - $ref: '#/parameters/x-api-key'
-      - $ref: '#/parameters/x-gw-ims-org-id'
-      - $ref: '#/parameters/x-sandbox-name'
-      - $ref: '#/parameters/accept'
-      - name: SCHEMA_ID
-        description: The `meta:altId` or URL-encoded `$id` value of the schema you want to generate sample data for.
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
         required: true
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        description: |-
+          The desired response format. For lookup requests, a `version` parameter must be included, with the following `Accept` header values being permitted:
+          <table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed+json; version=1</code></td><td>Returns only the basic details of the resource, with all inherited fields relegated to <code>$ref</code> and <code>allOf</code> properties.</td></tr><tr><td><code>application/vnd.adobe.xed-full+json; version=1</code></td><td>Returns the full details of the resource, including the details all fields inherited from other resources.</td></tr><tr><td><code>application/vnd.adobe.xed-notext+json; version=1</code></td><td>Returns only the basic details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-notext+json; version=1</code></td><td>Returns the full details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-desc+json; version=1</code></td><td>Returns the full details of the resource, including descriptions but with no titles.</td></tr></tbody></table>
+        required: true
+        schema:
+          type: string
+      - name: SCHEMA_ID
         in: path
-        type: string
+        description: The `meta:altId` or URL-encoded `$id` value of the schema you
+          want to generate sample data for.
+        required: true
+        schema:
+          type: string
       responses:
-        '200':
-          description: A successful response returns a sample ingestion file, mapped to the structure of the specified schema.
-          schema:
-            type: object
-            example:
-              "@id": "/uri-reference"
-              "xdm:name": "Example Offer Name"
-              "xdm:representations":
-                - "xdm:channel": "https://ns.adobe.com/xdm/common/uri"
-                  "xdm:components":
-                    - "@type": "https://ns.adobe.com/experience/offer-management/content-component-text"
-                      "dc:format": "application/vnd.adobe.photoshop"
-                      "dc:language":
-                        - "\n"
-                      "repo:id": "urn:aaid:sc:US:6dc33479-13ca-4b19-b25d-c805eff8a69e"
-                      "repo:name": "Example Repo Name"
-                      "repo:resolveURL": "https://plaftform.adobe.io/resolveByPath?path=&quot;/mycorp/content/projectx/fragment/prod/herobanners/banner14.html3&quot;"
-                  "xdm:placement": "https://ns.adobe.com/xdm/common/uri"
-              "xdm:status": "draft"
-              "xdm:tags":
-                - "https://ns.adobe.com/xdm/common/uri"
-        '404':
-          description: No schema could be found for the specified {SCHEMA_ID}. Double-check that you are providing a valid {SCHEMA_ID} and are using the correct {IMS_ORG} and {SANDBOX_NAME} headers for that schema before trying again.
-          schema:
-            $ref: '#/definitions/notFoundError'
-  '/rpc/auditlog/{RESOURCE_ID}':
+        "200":
+          description: "A successful response returns a sample ingestion file, mapped\
+            \ to the structure of the specified schema."
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  '@id': /uri-reference
+                  xdm:name: Example Offer Name
+                  xdm:representations:
+                  - xdm:channel: https://ns.adobe.com/xdm/common/uri
+                    xdm:components:
+                    - '@type': https://ns.adobe.com/experience/offer-management/content-component-text
+                      dc:format: application/vnd.adobe.photoshop
+                      dc:language:
+                      - |2+
+
+                      repo:id: urn:aaid:sc:US:6dc33479-13ca-4b19-b25d-c805eff8a69e
+                      repo:name: Example Repo Name
+                      repo:resolveURL: https://plaftform.adobe.io/resolveByPath?path=&quot;/mycorp/content/projectx/fragment/prod/herobanners/banner14.html3&quot;
+                    xdm:placement: https://ns.adobe.com/xdm/common/uri
+                  xdm:status: draft
+                  xdm:tags:
+                  - https://ns.adobe.com/xdm/common/uri
+        "404":
+          description: "No schema could be found for the specified {SCHEMA_ID}. Double-check\
+            \ that you are providing a valid {SCHEMA_ID} and are using the correct\
+            \ {IMS_ORG} and {SANDBOX_NAME} headers for that schema before trying again."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/notFoundError'
+  /rpc/auditlog/{RESOURCE_ID}:
     get:
       tags:
-      - "Audit log"
+      - Audit log
       summary: Retrieve a resource's audit log
-      description: >-
+      description: |-
         This endpoint retrieves a resource's audit log, which shows a list of all the changes made to the resource.
-
 
         >**NOTE**: For more information on using this operation, see the [audit log endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/audit-log.html) on Experience League.
       operationId: retrieveAuditLog
       parameters:
-      - $ref: '#/parameters/authorization'
-      - $ref: '#/parameters/x-api-key'
-      - $ref: '#/parameters/x-gw-ims-org-id'
-      - $ref: '#/parameters/x-sandbox-name'
-      - name: RESOURCE_ID
-        description: The `meta:altId` or URL-encoded `$id` value of the resource whose changes you wish to view.
-        in: path
+      - name: Authorization
+        in: header
+        description: "The access token which can be copied from your Experience Platform\
+          \ integration, prefixed with \"Bearer \". For more information on how to\
+          \ obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
         required: true
-        type: string
+        schema:
+          type: string
+      - name: x-api-key
+        in: header
+        description: "The API key which can be copied from your Experience Platform\
+          \ integration. For more information on how to obtain this value, visit the\
+          \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-gw-ims-org-id
+        in: header
+        description: "The IMS Organization ID which can be copied from your Experience\
+          \ Platform integration. For more information on how to obtain this value,\
+          \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+        required: true
+        schema:
+          type: string
+      - name: x-sandbox-name
+        in: header
+        description: "The name of the sandbox in which the operation will take place.\
+          \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en)\
+          \ for more information."
+        required: true
+        schema:
+          type: string
+      - name: RESOURCE_ID
+        in: path
+        description: The `meta:altId` or URL-encoded `$id` value of the resource whose
+          changes you wish to view.
+        required: true
+        schema:
+          type: string
       responses:
-        '200':
-          description: A successful response returns an array of change logs for the specified resource. Each change object provides details on what action was performed to which field(s), the user that made the change, and a timestamp for when the change was committed.
-          schema:
-            type: array
-            items:
-              type: object
-              properties:
-                id:
-                  type: string
-                  description: The `$id` of the resource that was changed. This value will typically represent the resource specified in the request path, but may represent a dependent resource if that is the source of the change.
-                updatedUser:
-                  type: string
-                  description: The ID of the user that updated the resource.
-                imsOrg:
-                  type: string
-                  description: The ID of the IMS Org that owns the resource.
-                updatedTime:
-                  type: string
-                  description: A timestamp of when the resource was updated.
-                requestId:
-                  type: string
-                  description: A unique ID for the request that retrieved the audit log data.
-                clientId:
-                  type: string
-                  description: The ID of the client that updated the resource.
-                sandboxId:
-                  type: string
-                  description: The ID of the sandbox that owns the resource.
-                updates:
-                  type: array
-                  description: A list of changes made to the specified resource or one of its dependent resources.
-                  items:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        description: The `$id` of the resource that was changed. This value will typically represent the resource specified in the request path, but may represent a dependent resource if that is the source of the change.
-                      xdmType:
-                        type: string
-                        description: The type of XDM resource that was changed.
-                      action:
-                        type: string
-                        description: The type of change that was made.
-                      path:
-                        type: string
-                        description: A [JSON Pointer](https://experienceleague.adobe.com/docs/experience-platform/landing/platform-apis/api-fundamentals.html?lang=en#json-pointer) string indicating the path to the specific field that was changed or added.
-                      value:
-                        type: string
-                        description: The value that was assigned to the new or updated field.
-            example:
-              - id: https://ns.adobe.com/{TENANT_ID}/schemas/50649eb1b040bf042d6400a0335901cd2a97d31a4eac4330
-                updatedUser: "{USER_ID}"
-                imsOrg: "{IMS_ORG}"
-                updatedTime: 02-19-2021 05:43:56
-                requestId: a14NMF0jd6BIfyXaHdTDl4bC4R0r9rht
-                clientId: "{CLIENT_ID}"
-                sandBoxId: 28e74200-e3de-11e9-8f5d-7f27416c5f0d
-                updates:
-                - id: https://ns.adobe.com/{TENANT_ID}/schemas/50649eb1b040bf042d6400a0335901cd2a97d31a4eac4330
-                  xdmType: schemas
-                  action: remove
-                  path: "/meta:usageCount"
-                  value: 0
-              - id: https://ns.adobe.com/{TENANT_ID}/schemas/50649eb1b040bf042d6400a0335901cd2a97d31a4eac4330
-                updatedUser: "{USER_ID}"
-                imsOrg: "{IMS_ORG}"
-                updatedTime: 02-19-2021 05:43:56
-                requestId: pFQbgmWrdbJrNB9GdxTSGECpXYWspu68
-                clientId: "{CLIENT_ID}"
-                sandBoxId: 28e74200-e3de-11e9-8f5d-7f27416c5f0d
-                updates:
-                - id: https://ns.adobe.com/{TENANT_ID}/classes/11052164b588f0c29584bf6ae1a6663a59aa65426c82389f
-                  xdmType: classes
-                  action: remove
-                  path: "/definitions/customFields/properties/_{TENANT_ID}/properties/loyaltySunday_ABC"
-                  value:
-                    title: LoyaltySundayABC
-                    description: ''
-                    type: string
-                    isRequired: false
-                    required: []
-                    meta:xdmType: string
-                - id: https://ns.adobe.com/{TENANT_ID}/classes/11052164b588f0c29584bf6ae1a6663a59aa65426c82389f
-                  xdmType: classes
-                  action: remove
-                  path: "/definitions/customFields/properties/_{TENANT_ID}/properties/loyaltyMoxee_XYZ"
-                  value:
-                    title: LoyaltyMoxeeXYZ
-                    description: ''
-                    type: string
-                    isRequired: false
-                    required: []
-                    meta:xdmType: string
-
-parameters:
-  containerIdList:
-    name: CONTAINER_ID
-    description: The name of the container that you want to list resources from. To list core resources provided by Adobe, use `global`. To list custom resources defined by your organization, use `tenant`.
-    required: true
-    in: path
-    type: string
-  containerIdLookup:
-    name: CONTAINER_ID
-    description: The name of the container that you want to retrieve a resource from. To retrieve a core resource provided by Adobe, use `global`. To retrieve a custom resource defined by your organization, use `tenant`.
-    required: true
-    in: path
-    type: string
-  SCHEMA_ID:
-    name: SCHEMA_ID
-    description: The `meta:altId` or URL-encoded `$id` of the schema in question.
-    required: true
-    in: path
-    type: string
-  BEHAVIOR_ID:
-    name: BEHAVIOR_ID
-    description: The `meta:altId` or URL-encoded `$id` of the behavior in question.
-    required: true
-    in: path
-    type: string
-  CLASS_ID:
-    name: CLASS_ID
-    description: The `meta:altId` or URL-encoded `$id` of the class in question.
-    required: true
-    in: path
-    type: string
-  MIXIN_ID:
-    name: MIXIN_ID
-    description: The `meta:altId` or URL-encoded `$id` of the mixin in question.
-    required: true
-    in: path
-    type: string
-  DATA_TYPE_ID:
-    name: DATA_TYPE_ID
-    description: The `meta:altId` or URL-encoded `$id` of the data type in question.
-    required: true
-    in: path
-    type: string
-  DESCRIPTOR_ID:
-    name: DESCRIPTOR_ID
-    description: The unique ID (`@id`) of the descriptor in question.
-    required: true
-    in: path
-    type: string
-  UNION_ID:
-    name: UNION_ID
-    description: The `meta:altId` or URL-encoded `$id` of the union schema in question.
-    required: true
-    in: path
-    type: string
-  authorization:
-    name: Authorization
-    description: 'The access token which can be copied from your Experience Platform integration, prefixed with "Bearer ". For more information on how to obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).'
-    required: true
-    type: string
-    in: header
-  x-gw-ims-org-id:
-    name: x-gw-ims-org-id
-    description: 'The IMS Organization ID which can be copied from your Experience Platform integration. For more information on how to obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).'
-    required: true
-    type: string
-    in: header
-  x-api-key:
-    name: x-api-key
-    description: 'The API key which can be copied from your Experience Platform integration. For more information on how to obtain this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).'
-    required: true
-    type: string
-    in: header
-  x-sandbox-name:
-    name: x-sandbox-name
-    description: 'The name of the sandbox in which the operation will take place. See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.'
-    required: true
-    type: string
-    in: header
-  content-type:
-    name: Content-Type
-    description: The type of content being sent in the body of the request. When sending requests that include payloads to the Schema Registry API, this header must be included with a value of `application/json`.
-    required: true
-    type: string
-    in: header
-  accept:
-    name: Accept
-    description: >-
-      The desired response format. For lookup requests, a `version` parameter must be included, with the following `Accept` header values being permitted:
-
-      <table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed+json; version=1</code></td><td>Returns only the basic details of the resource, with all inherited fields relegated to <code>$ref</code> and <code>allOf</code> properties.</td></tr><tr><td><code>application/vnd.adobe.xed-full+json; version=1</code></td><td>Returns the full details of the resource, including the details all fields inherited from other resources.</td></tr><tr><td><code>application/vnd.adobe.xed-notext+json; version=1</code></td><td>Returns only the basic details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-notext+json; version=1</code></td><td>Returns the full details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-desc+json; version=1</code></td><td>Returns the full details of the resource, including descriptions but with no titles.</td></tr></tbody></table>
-    required: true
-    type: string
-    in: header
-  acceptListing:
-    name: Accept
-    description: >-
-      The desired response format. For listing calls, the following `Accept` header values are permitted: 
-      
-      <table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed-id+json</code></td><td>Returns a short summary of each resource, generally the preferred header for listing.</td></tr><tr><td><code>application/vnd.adobe.xed+json</code></td><td>Returns full JSON for each resource, with the original <code>$ref</code> and <code>allOf</code> attributes included.</td></tr></tbody></table>
-    required: true
-    type: string
-    in: header
-  acceptDescriptors:
-    name: Accept
-    description: >-
-      The desired response format. Descriptors require unique `Accept` headers using `xdm` instead of `xed`. The following values are permitted:
-
-      <table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xdm-id+json</code></td><td>Returns a list of descriptor IDs, grouped by their <code>@type</code>.</td></tr><tr><td><code>application/vnd.adobe.xdm-link+json</code></td><td>Returns a list of descriptor API paths, grouped by their <code>@type</code>.</td></tr><tr><td><code>application/vnd.adobe.xdm+json</code></td><td>Returns a list of descriptor objects, grouped by their <code>@type</code>.</td></tr><tr><td><code>application/vnd.adobe.xdm-v2{-id/-link}+json</code></td><td>Including the <code>-v2</code> option in any of the above <code>Accept</code> headers permits paging functionality, returning a results array with a <code>_page</code> attribute that can be used to request the next page if needed.</td></tr></tbody></table>
-    required: true
-    type: string
-    in: header
-  property:
-    name: property
-    description: A comma-separated list of top-level object properties to be returned in the response. For example, `property=meta:intendedToExtend==https://ns.adobe.com/xdm/context/profile` returns only field groups that are compatible with the XDM Individual Profile class.
-    in: query
-    type: string
-    required: false
-  orderBy:
-    name: orderby
-    description: Sort the listed resources by specified fields. For example `orderby=title` sorts results by title in ascending order (A-Z). Adding a `-` before the field name (`orderby=-title`) sorts items in descending order (Z-A). Multiple fields can also be included to denote primary and secondary sort orders (for example, `orderby=title,description`).
-    required: false
-    in: query
-    type: string
-  limit:
-    name: limit
-    description: >-
-      When used in conjunction with an `orderby` parameter, `limit` restricts the maximum number of items that should be returned for a given request. This parameter cannot be used without an `orderby` parameter present.
-      
-
-      The `limit` parameter specifies a positive integer (between `0` and `500`) as a *hint* as to the maximum number of items that should be returned. For example, `limit=5` returns only five resources in the list. However, this value is not strictly honored. The actual response size may be smaller or larger as constrained by the need to provide the reliable operation of the `start` parameter, if one is provided.
-    required: false
-    in: query
-    type: number
-  start:
-    name: start
-    description: >-
-      When used in conjunction with an `orderby` parameter, `start` specifies where the paginated list of items should begin. This parameter cannot be used without an `orderby` parameter present.
-      
-      
-      Typically, this parameter is omitted in order to obtain the first page of results. After that, `start` should be set to the maximum value of the primary sort property of the `orderby` field received in the previous page. The API response then returns entries beginning with those that have a primary sort property from `orderby` strictly greater than (for ascending) or strictly less than (for descending) the specified value.
-
-
-      For example, if the `orderby` parameter is set to `orderby=name,firstname`, the `start` parameter would contain a value for the `name` property. In this case, if you wanted to show the next 20 entries of a resource immediately following the name "Miller", you would use: `?orderby=name,firstname&start=Miller&limit=20`.
-    required: false
-    in: query
-    type: string
-  patchPayload:
-    name: body
-    description: The request body accepts a JSON Patch payload.
-    required: true
-    in: body
-    schema:
-      '$ref': '#/definitions/patchSchema'
-  patchClassPayload:
-    name: body
-    description: The request body accepts a JSON Patch payload.
-    required: true
-    in: body
-    schema:
-      $ref: '#/definitions/patchClass'
-  patchFieldGroupPayload:
-    name: body
-    description: The request body accepts a JSON Patch payload.
-    required: true
-    in: body
-    schema:
-      $ref: '#/definitions/patchFieldGroup'
-  createSchemaPayload:
-    name: body
-    description: The JSON payload must include an `allOf` attribute referencing the `$id` of the base class the that the schema will implement.
-    required: true
-    in: body
-    schema:
-      "$ref": '#/definitions/createSchema'
-  replaceSchemaPayload:
-    name: body
-    description: The JSON payload must include all of the fields that were originally required for creating the schema, but with updated values. This includes an `allOf` attribute referencing the `$id` of the class the schema will implement.
-    required: true
-    in: body
-    schema:
-      "$ref": '#/definitions/replaceSchema'
-  createClassPayload:
-    name: body
-    description: The request payload must include an `allOf` attribute referencing either 'https://ns.adobe.com/xdm/data/record' or 'https://ns.adobe.com/xdm/data/time-series'. This value represents the data behavior upon which the class is based. `allOf` may also optionally include field groups or custom fields that will be included each time the class is used.
-    required: true
-    in: body
-    schema:
-      "$ref": '#/definitions/createClass'
-  replaceClassPayload:
-    name: body
-    description: The JSON payload must include all of the fields that were originally required for creating the class, but with updated values. This includes an `allOf` attribute referencing the behavior of the class.
-    required: true
-    in: body
-    schema:
-      "$ref": '#/definitions/replaceClass'
-  fieldGroupPayload:
-    name: body
-    description: The JSON payload must include a 'meta:intendedToExtend' field listing the '$id' of the class(es) with which the field group is compatible.
-    required: true
-    in: body
-    schema:
-      $ref: '#/definitions/createFieldGroup'
-  replaceFieldGroupPayload:
-    name: body
-    description: The JSON payload must include all of the fields that were originally required for creating the field group, but with updated values. This includes an `allOf` attribute referencing the `$id` of the class the schema will implement.
-    required: true
-    in: body
-    schema:
-      "$ref": '#/definitions/replaceFieldGroup'
-  createDataTypePayload:
-    name: body
-    description: >- 
-      Unlike field groups, defining a data type does not require `meta:extends` or `meta:intendedToExtend` fields, nor do fields need to be nested to avoid collisions.
-
-      When it comes to defining the field structure of data type itself, you can use primitive types (like `string` or `object`) or you can reference other existing data types through `$ref` attributes. See the guide on [defining custom XDM fields in the API](../tutorials/custom-fields-api.md) for detailed guidance on the expected format for different XDM field types.
-    required: true
-    in: body
-    schema:
-      "$ref": '#/definitions/createDataType'
-  patchDataTypePayload:
-    name: body
-    description: The request body accepts a JSON Patch payload.
-    required: true
-    in: body
-    schema:
-      $ref: '#/definitions/patchDataType'
-  replaceDataTypePayload:
-    name: body
-    description: The JSON payload must include all of the fields that were originally required for creating the data type, but with updated values.
-    required: true
-    in: body
-    schema:
-      "$ref": '#/definitions/replaceDataType'
-  descriptorPayload:
-    name: body
-    description: The required request payload fields vary based on the `@type` of descriptor being defined. For details on the requirements for each descriptor type, refer to the section on [defining descriptors](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/descriptors.html?lang=en#defining-descriptors) in the API guide.
-    required: true
-    in: body
-    schema:
-      '$ref': '#/definitions/createDescriptor'
-
-
-definitions:
-  statsResponse:
-    type: object
-    properties:
-      imsOrg:
-        type: string
-        description: The ID of the IMS Organization that the returned stats apply to.
-        example: '{IMS_ORG}'
-      tenantId:
-        type: string
-        description: The tenant ID of the IMS Organization identified under `imsOrg`.
-        example: '{TENANT_ID}'
-      counts:
-        type: object
-        description: Provides the total counts of different XDM resources currently stored in the Schema Library.
-        properties:
-          schemas:
-            type: integer
-            description: The number of schemas currently stored in the Schema Library.
-            example: 4
-          mixins:
-            type: integer
-            description: The number of field groups currently stored in the Schema Library.
-            example: 38
-          datatypes:
-            type: integer
-            description: The number of data types currently stored in the Schema Library.
-            example: 382
-          classes:
-            type: integer
-            description: The number of classes currently stored in the Schema Library.
-            example: 5
-          unions:
-            type: integer
-            description: The number of union schemas currently stored in the Schema Library.
-            example: 2
-      recentlyCreatedResources:
-        type: array
-        description: Array of objects containing details of recently created resources.
-        items:
-          $ref: '#/definitions/listResponseItemWithVersion'
-      recentlyUpdatedResources:
-        type: array
-        description: Array of objects containing details of recently updated resources.
-        items:
-          $ref: '#/definitions/listResponseItemWithVersion'   
-      classUsage:
-        type: array
-        description: Provides information about which schemas are being employed for each class in the Schema Library.
-        items:
-          $ref: '#/definitions/classUsageItem'
-        example:
+        "200":
+          description: "A successful response returns an array of change logs for\
+            \ the specified resource. Each change object provides details on what\
+            \ action was performed to which field(s), the user that made the change,\
+            \ and a timestamp for when the change was committed."
+          content:
+            application/json:
+              schema:
+                type: array
+                example:
+                - id: "https://ns.adobe.com/{TENANT_ID}/schemas/50649eb1b040bf042d6400a0335901cd2a97d31a4eac4330"
+                  updatedUser: "{USER_ID}"
+                  imsOrg: "{IMS_ORG}"
+                  updatedTime: 02-19-2021 05:43:56
+                  requestId: a14NMF0jd6BIfyXaHdTDl4bC4R0r9rht
+                  clientId: "{CLIENT_ID}"
+                  sandBoxId: 28e74200-e3de-11e9-8f5d-7f27416c5f0d
+                  updates:
+                  - id: "https://ns.adobe.com/{TENANT_ID}/schemas/50649eb1b040bf042d6400a0335901cd2a97d31a4eac4330"
+                    xdmType: schemas
+                    action: remove
+                    path: /meta:usageCount
+                    value: 0
+                - id: "https://ns.adobe.com/{TENANT_ID}/schemas/50649eb1b040bf042d6400a0335901cd2a97d31a4eac4330"
+                  updatedUser: "{USER_ID}"
+                  imsOrg: "{IMS_ORG}"
+                  updatedTime: 02-19-2021 05:43:56
+                  requestId: pFQbgmWrdbJrNB9GdxTSGECpXYWspu68
+                  clientId: "{CLIENT_ID}"
+                  sandBoxId: 28e74200-e3de-11e9-8f5d-7f27416c5f0d
+                  updates:
+                  - id: "https://ns.adobe.com/{TENANT_ID}/classes/11052164b588f0c29584bf6ae1a6663a59aa65426c82389f"
+                    xdmType: classes
+                    action: remove
+                    path: "/definitions/customFields/properties/_{TENANT_ID}/properties/loyaltySunday_ABC"
+                    value:
+                      title: LoyaltySundayABC
+                      description: ""
+                      type: string
+                      isRequired: false
+                      required: []
+                      meta:xdmType: string
+                  - id: "https://ns.adobe.com/{TENANT_ID}/classes/11052164b588f0c29584bf6ae1a6663a59aa65426c82389f"
+                    xdmType: classes
+                    action: remove
+                    path: "/definitions/customFields/properties/_{TENANT_ID}/properties/loyaltyMoxee_XYZ"
+                    value:
+                      title: LoyaltyMoxeeXYZ
+                      description: ""
+                      type: string
+                      isRequired: false
+                      required: []
+                      meta:xdmType: string
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: "The `$id` of the resource that was changed. This\
+                        \ value will typically represent the resource specified in\
+                        \ the request path, but may represent a dependent resource\
+                        \ if that is the source of the change."
+                    updatedUser:
+                      type: string
+                      description: The ID of the user that updated the resource.
+                    imsOrg:
+                      type: string
+                      description: The ID of the IMS Org that owns the resource.
+                    updatedTime:
+                      type: string
+                      description: A timestamp of when the resource was updated.
+                    requestId:
+                      type: string
+                      description: A unique ID for the request that retrieved the
+                        audit log data.
+                    clientId:
+                      type: string
+                      description: The ID of the client that updated the resource.
+                    sandboxId:
+                      type: string
+                      description: The ID of the sandbox that owns the resource.
+                    updates:
+                      type: array
+                      description: A list of changes made to the specified resource
+                        or one of its dependent resources.
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            description: "The `$id` of the resource that was changed.\
+                              \ This value will typically represent the resource specified\
+                              \ in the request path, but may represent a dependent\
+                              \ resource if that is the source of the change."
+                          xdmType:
+                            type: string
+                            description: The type of XDM resource that was changed.
+                          action:
+                            type: string
+                            description: The type of change that was made.
+                          path:
+                            type: string
+                            description: "A [JSON Pointer](https://experienceleague.adobe.com/docs/experience-platform/landing/platform-apis/api-fundamentals.html?lang=en#json-pointer)\
+                              \ string indicating the path to the specific field that\
+                              \ was changed or added."
+                          value:
+                            type: string
+                            description: The value that was assigned to the new or
+                              updated field.
+components:
+  schemas:
+    statsResponse:
+      type: object
+      properties:
+        imsOrg:
+          type: string
+          description: The ID of the IMS Organization that the returned stats apply
+            to.
+          example: "{IMS_ORG}"
+        tenantId:
+          type: string
+          description: The tenant ID of the IMS Organization identified under `imsOrg`.
+          example: "{TENANT_ID}"
+        counts:
+          type: object
+          properties:
+            schemas:
+              type: integer
+              description: The number of schemas currently stored in the Schema Library.
+              example: 4
+            mixins:
+              type: integer
+              description: The number of field groups currently stored in the Schema
+                Library.
+              example: 38
+            datatypes:
+              type: integer
+              description: The number of data types currently stored in the Schema
+                Library.
+              example: 382
+            classes:
+              type: integer
+              description: The number of classes currently stored in the Schema Library.
+              example: 5
+            unions:
+              type: integer
+              description: The number of union schemas currently stored in the Schema
+                Library.
+              example: 2
+          description: Provides the total counts of different XDM resources currently
+            stored in the Schema Library.
+        recentlyCreatedResources:
+          type: array
+          description: Array of objects containing details of recently created resources.
+          items:
+            $ref: '#/components/schemas/listResponseItemWithVersion'
+        recentlyUpdatedResources:
+          type: array
+          description: Array of objects containing details of recently updated resources.
+          items:
+            $ref: '#/components/schemas/listResponseItemWithVersion'
+        classUsage:
+          type: array
+          description: Provides information about which schemas are being employed
+            for each class in the Schema Library.
+          example:
           - $id: https://ns.adobe.com/xdm/context/profile
             title: XDM Individual Profile
             numberOfSchemas: 3
             schemas:
-            - $id: https://ns.adobe.com/{TENANT_ID}/schemas/3d569c62921ac9371ad148afbaec3891547aca2a49575cef
+            - $id: "https://ns.adobe.com/{TENANT_ID}/schemas/3d569c62921ac9371ad148afbaec3891547aca2a49575cef"
               title: Customers
               description: Basic profile schema.
-            - $id: https://ns.adobe.com/{TENANT_ID}/schemas/ad79ff2868d65545812ffe6745a2085d0b5deff379bc3faf
+            - $id: "https://ns.adobe.com/{TENANT_ID}/schemas/ad79ff2868d65545812ffe6745a2085d0b5deff379bc3faf"
               title: Loyalty Members
               description: Describes members of the loyalty program.
-            - $id: https://ns.adobe.com/{TENANT_ID}/schemas/274f17bc5807ff307a046bab1489fb18,
-              title: Tenant Data Schema,
-              meta:altId: _{TENANT_ID}.schemas.274f17bc5807ff307a046bab1489fb18,
+            - $id: "https://ns.adobe.com/{TENANT_ID}/schemas/274f17bc5807ff307a046bab1489fb18,"
+              title: "Tenant Data Schema,"
+              meta:altId: "_{TENANT_ID}.schemas.274f17bc5807ff307a046bab1489fb18,"
           - $id: https://ns.adobe.com/xdm/context/profile
             title: XDM ExperienceEvent
             numberOfSchemas: 1
             schemas:
-            - $id: https://ns.adobe.com/{TENANT_ID}/schemas/7a3739168b1cb52b1489f6f3c43eaa66ff155fa87cd1e5ee
+            - $id: "https://ns.adobe.com/{TENANT_ID}/schemas/7a3739168b1cb52b1489f6f3c43eaa66ff155fa87cd1e5ee"
               title: Website Event
               description: Describes a web traffic event.
-  classUsageItem:
-    type: object
-    properties:
-      $id:
-        type: string
-        description: The URI ID of the class whose usage stats are being listed.
-        example: https://ns.adobe.com/xdm/context/profile
-      title:
-        type: string
-        description: The title of the class whose usage stats are being listed.
-        example: XDM Individual Profile
-      numberOfSchemas:
-        type: integer
-        description: The number of schemas that are based on the class.
-        example: 2
-      schemas:
-        type: array
-        description: A list of objects that describe the basic details about the schemas that are based on the class.
-        items:
-          $ref: '#/definitions/listResponseItem'
-  linksBasic:
-    type: object
-    description: Contains various links related to the response.
-    properties:
-      next:
-        type: string
-        description: A URI for the next page in the response, if one exists. Contains `null` if this is the last or only page in the response.
-        example:
-  linksSchemas:
-    allOf:
-      - $ref: '#/definitions/linksBasic'
-      - properties:
+          items:
+            $ref: '#/components/schemas/classUsageItem'
+    classUsageItem:
+      type: object
+      properties:
+        $id:
+          type: string
+          description: The URI ID of the class whose usage stats are being listed.
+          example: https://ns.adobe.com/xdm/context/profile
+        title:
+          type: string
+          description: The title of the class whose usage stats are being listed.
+          example: XDM Individual Profile
+        numberOfSchemas:
+          type: integer
+          description: The number of schemas that are based on the class.
+          example: 2
+        schemas:
+          type: array
+          description: A list of objects that describe the basic details about the
+            schemas that are based on the class.
+          items:
+            $ref: '#/components/schemas/listResponseItem'
+    linksBasic:
+      type: object
+      properties:
+        next:
+          type: string
+          description: "A URI for the next page in the response, if one exists. Contains\
+            \ `null` if this is the last or only page in the response."
+          example: "null"
+      description: Contains various links related to the response.
+    linksSchemas:
+      allOf:
+      - $ref: '#/components/schemas/linksBasic'
+      - type: object
+        properties:
           global_schemas:
             type: object
-            description: Contains an `href` property that links to the path for retrieving schemas from the global container.
             properties:
               href:
                 type: string
                 description: The path for retrieving schemas from the global container.
                 example: https://platform.adobe.io/data/foundation/schemaregistry/global/schemas
-  listSchemasResponse:
-    allOf:
-      - $ref: '#/definitions/listResponseBasic'
-      - properties:
-          _links:
-            $ref: '#/definitions/linksSchemas'
-  listResponse:
-    allOf:
-      - $ref: '#/definitions/listResponseBasic'
-      - properties:
-          _links:
-            $ref: '#/definitions/linksBasic'
-  listFieldGroupsResponse:
-    allOf:
-      - $ref: '#/definitions/listResponse'
-      - properties:
-          results:
-            items:
-              $ref: '#/definitions/singleFieldGroupResponse'
-    example:
-      results:
-        - "$id": https://ns.adobe.com/xdm/context/profile-person-details
-          meta:altId: _xdm.context.profile-person-details
-          meta:resourceType: mixins
-          version: 1.27.4
-          title: Demographic Details
-          type: object
-          description: Demographic information such as name, gender, and birth date of an
-            individual.
-          definitions:
-            profile-person-details:
-              properties:
-                person:
-                  title: Person
-                  "$ref": https://ns.adobe.com/xdm/context/person
-                  description: An individual actor, contact, or owner.
-                  type: object
-                  meta:xdmType: object
-                  meta:xdmField: xdm:person
-          allOf:
-          - "$ref": https://ns.adobe.com/xdm/common/extensible#/definitions/%40context
-            type: object
-            meta:xdmType: object
-          - "$ref": "#/definitions/profile-person-details"
-            type: object
-            meta:xdmType: object
-          meta:extensible: true
-          meta:abstract: true
-          meta:intendedToExtend:
-          - https://ns.adobe.com/xdm/context/profile
-          meta:xdmType: object
-          meta:status: stable
-          "$schema": http://json-schema.org/draft-06/schema#
-          meta:registryMetadata:
-            repo:createdDate: 1635361816945
-            repo:lastModifiedDate: 1635361816945
-            eTag: 9f6a76cf4e115d0a3db3900fb418979ebea28bce47967484a1a0b2a2c32514cb
-            meta:globalLibVersion: 1.27.4
-            meta:usageCount: 316
-          meta:tags:
-            industry:
-            - all
-          meta:createdDate: '2020-08-10'
-        - "$id": https://ns.adobe.com/xdm/context/profile-personal-details
-          meta:altId: _xdm.context.profile-personal-details
-          meta:resourceType: mixins
-          version: 1.27.4
-          title: Personal Contact Details
-          type: object
-          description: Contact information for an individual person such as home address,
-            phone number, fax, and email.
-          definitions:
-            profile-personal-details:
-              properties:
-                faxPhone:
-                  title: Fax phone
-                  "$ref": https://ns.adobe.com/xdm/context/phonenumber
-                  description: Fax phone number.
-                  type: object
-                  meta:xdmType: object
-                  meta:xdmField: xdm:faxPhone
-                homeAddress:
-                  title: Home address
-                  "$ref": https://ns.adobe.com/xdm/common/address
-                  description: A home postal address.
-                  type: object
-                  meta:xdmType: object
-                  meta:xdmField: xdm:homeAddress
-                homePhone:
-                  title: Home phone
-                  "$ref": https://ns.adobe.com/xdm/context/phonenumber
-                  description: Home phone number.
-                  type: object
-                  meta:xdmType: object
-                  meta:xdmField: xdm:homePhone
-                mobilePhone:
-                  title: Mobile phone
-                  "$ref": https://ns.adobe.com/xdm/context/phonenumber
-                  description: Mobile phone number.
-                  type: object
-                  meta:xdmType: object
-                  meta:xdmField: xdm:mobilePhone
-                personalEmail:
-                  title: Personal email
-                  "$ref": https://ns.adobe.com/xdm/context/emailaddress
-                  description: A personal email address.
-                  type: object
-                  meta:xdmType: object
-                  meta:xdmField: xdm:personalEmail
-          allOf:
-          - "$ref": https://ns.adobe.com/xdm/common/extensible#/definitions/%40context
-            type: object
-            meta:xdmType: object
-          - "$ref": "#/definitions/profile-personal-details"
-            type: object
-            meta:xdmType: object
-          meta:extensible: true
-          meta:abstract: true
-          meta:intendedToExtend:
-          - https://ns.adobe.com/xdm/context/profile
-          meta:xdmType: object
-          meta:status: stable
-          "$schema": http://json-schema.org/draft-06/schema#
-          meta:registryMetadata:
-            repo:createdDate: 1635361816961
-            repo:lastModifiedDate: 1635361816961
-            eTag: 750a04f69224e9fab367c6663199218dbd524852652627756284b4333fd7b27b
-            meta:globalLibVersion: 1.27.4
-            meta:usageCount: 300
-          meta:tags:
-            industry:
-            - all
-          meta:createdDate: '2020-08-10'
-      _page:
-        orderby: updated
-        next:
-        count: 2
-      _links:
-        next:
-
-  listResponseBasic:
-    type: object
-    properties:
-      results:
-        type: array
-        description: Lists the basic details of the returned XDM resources.
-        items:
-          $ref: '#/definitions/listResponseItemWithVersion'
-      _page:
-        type: object
-        description: Contains pagination information related to the response.
+            description: Contains an `href` property that links to the path for retrieving
+              schemas from the global container.
+    listSchemasResponse:
+      allOf:
+      - $ref: '#/components/schemas/listResponseBasic'
+      - type: object
         properties:
-          orderby:
-            type: string
-            description: The attribute that results are sorted by.
-            example: title
-          next:
-            type: string
-            description: A URI for the next page in the response, if one exists. Contains `null` if this is the last or only page in the response.
-            example:
-          count:
-            type: integer
-            description: The number of results returned per page.
-            example: 2
-      _links:
-        $ref: '#/definitions/linksBasic'
-    example:
-      results:
-        - "$id": https://ns.adobe.com/{TENANT_ID}/schemas/0238be93d3e7a06aec5e0655955901ec
-          meta:altId: _{TENANT_ID}.schemas.0238be93d3e7a06aec5e0655955901ec
-          version: '1.4'
+          _links:
+            $ref: '#/components/schemas/linksSchemas'
+    listResponse:
+      allOf:
+      - $ref: '#/components/schemas/listResponseBasic'
+      - type: object
+        properties:
+          _links:
+            $ref: '#/components/schemas/linksBasic'
+    listFieldGroupsResponse:
+      allOf:
+      - $ref: '#/components/schemas/listResponse'
+      - type: object
+        properties:
+          results:
+            type: object
+    listResponseBasic:
+      type: object
+      properties:
+        results:
+          type: array
+          description: Lists the basic details of the returned XDM resources.
+          items:
+            $ref: '#/components/schemas/listResponseItemWithVersion'
+        _page:
+          type: object
+          properties:
+            orderby:
+              type: string
+              description: The attribute that results are sorted by.
+              example: title
+            next:
+              type: string
+              description: "A URI for the next page in the response, if one exists.\
+                \ Contains `null` if this is the last or only page in the response."
+              example: "null"
+            count:
+              type: integer
+              description: The number of results returned per page.
+              example: 2
+          description: Contains pagination information related to the response.
+        _links:
+          $ref: '#/components/schemas/linksBasic'
+      example:
+        results:
+        - $id: "https://ns.adobe.com/{TENANT_ID}/schemas/0238be93d3e7a06aec5e0655955901ec"
+          meta:altId: "_{TENANT_ID}.schemas.0238be93d3e7a06aec5e0655955901ec"
+          version: "1.4"
           title: Hotels
-        - "$id": https://ns.adobe.com/{TENANT_ID}/schemas/0ef4ce0d390f0809fad490802f53d30b
-          meta:altId: _{TENANT_ID}.schemas.0ef4ce0d390f0809fad490802f53d30b
-          version: '1.0'
+        - $id: "https://ns.adobe.com/{TENANT_ID}/schemas/0ef4ce0d390f0809fad490802f53d30b"
+          meta:altId: "_{TENANT_ID}.schemas.0ef4ce0d390f0809fad490802f53d30b"
+          version: "1.0"
           title: Loyalty Members
-      _page:
-        orderby: title
-        next:
-        count: 2
-      _links:
-        next:
-        global_schemas:
-          href: https://platform.adobe.io/data/foundation/schemaregistry/global/schemas
-  listResponseItem:
-    type: object
-    properties:
-      title:
-        type: string
-        description: The title of the XDM resource.
-        example: Tenant Data Schema
-      $id:
-        type: string
-        description: The URI ID of the XDM resource.
-        example: 'https://ns.adobe.com/{TENANT_ID}/schemas/274f17bc5807ff307a046bab1489fb18'
-      meta:altId:
-        type: string
-        description: An alternate dot-notation ID for the XDM resource.
-        example: '_{TENANT_ID}.schemas.274f17bc5807ff307a046bab1489fb18'
-  listResponseItemWithVersion:
-    allOf:
-      - $ref: '#/definitions/listResponseItem'
-      - properties:
+        _page:
+          orderby: title
+          count: 2
+        _links:
+          global_schemas:
+            href: https://platform.adobe.io/data/foundation/schemaregistry/global/schemas
+    listResponseItem:
+      type: object
+      properties:
+        title:
+          type: string
+          description: The title of the XDM resource.
+          example: Tenant Data Schema
+        $id:
+          type: string
+          description: The URI ID of the XDM resource.
+          example: "https://ns.adobe.com/{TENANT_ID}/schemas/274f17bc5807ff307a046bab1489fb18"
+        meta:altId:
+          type: string
+          description: An alternate dot-notation ID for the XDM resource.
+          example: "_{TENANT_ID}.schemas.274f17bc5807ff307a046bab1489fb18"
+    listResponseItemWithVersion:
+      allOf:
+      - $ref: '#/components/schemas/listResponseItem'
+      - type: object
+        properties:
           version:
             type: string
             description: The current version of the XDM resource.
-            example: '1.1'
-  listUnionsResponse:
-    type: object
-    properties: 
-      results:
-        type: array
-        description: Lists the returned union schemas.
-        items:
-              $ref: '#/definitions/unionBasic'
-    example:
-      results:
-        - "$id": https://ns.adobe.com/xdm/context/profile__union
+            example: "1.1"
+    listUnionsResponse:
+      type: object
+      properties:
+        results:
+          type: array
+          description: Lists the returned union schemas.
+          items:
+            $ref: '#/components/schemas/unionBasic'
+      example:
+        results:
+        - $id: https://ns.adobe.com/xdm/context/profile__union
           meta:altId: _xdm.context.profile__union
           meta:resourceType: unions
-          version: '1.0'
+          version: "1.0"
           title: XDM Individual Profile
           type: object
-          description: An XDM Individual Profile forms a singular representation of the attributes
-            and interests of both identified and partially-identified individuals. Less-identified
-            profiles may contain only anonymous behavioral signals, such as browser cookies,
-            while highly-identified profiles may contain detailed personal information such
-            as name, date of birth, location, and email address. As a profile grows, it becomes
-            a robust repository of personal information, identification information, contact
-            details, and communication preferences for an individual.
+          description: "An XDM Individual Profile forms a singular representation\
+            \ of the attributes and interests of both identified and partially-identified\
+            \ individuals. Less-identified profiles may contain only anonymous behavioral\
+            \ signals, such as browser cookies, while highly-identified profiles may\
+            \ contain detailed personal information such as name, date of birth, location,\
+            \ and email address. As a profile grows, it becomes a robust repository\
+            \ of personal information, identification information, contact details,\
+            \ and communication preferences for an individual."
           allOf:
           - {}
-          - "$ref": https://ns.adobe.com/xdm/context/profile-test-profile
-          - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/e16d03cd4f0f1cd0f837ceada0aa478e
-          - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/03a07059cad2a4d772385bcf8105750f
-          - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/6287e6dfaf504f1eb47842492431255d
-          - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/5a55c7ba8bfe66d1ec0fd5b7e6a2a280c45c6e3312c259ef
-          - "$ref": https://ns.adobe.com/xdm/mixins/profile-consents
-          - "$ref": https://ns.adobe.com/xdm/common/external-source-system-audit-details
-          - "$ref": https://ns.adobe.com/xdm/context/profile-person-details
-          - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/1e9576c98a5d2a67ac90da1a271f5eb2
-          - "$ref": https://ns.adobe.com/xdm/context/profile-privacy
-          - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/44850059caa530684c4507d0e01647e9
-          - "$ref": https://ns.adobe.com/xdm/mixins/profile/profile-loyalty-details
-          - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/d0b9284f0610076e97f57dfadf78b3de
-          - "$ref": https://ns.adobe.com/experience/campaign/profile-all
-          - "$ref": https://ns.adobe.com/xdm/context/profile-personal-details
-          - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/811a7c6627d5af6680cdfebf81c101c2
-          - "$ref": https://ns.adobe.com/experience/profile-edgeregion
-          - "$ref": https://ns.adobe.com/xdm/context/profile
-          - "$ref": https://ns.adobe.com/xdm/context/identitymap
-          - "$ref": https://ns.adobe.com/experience/profile/profile-all
-          - "$ref": https://ns.adobe.com/xdm/context/profile-segmentation
-          - "$ref": https://ns.adobe.com/xdm/context/profile-preferences-details
-          - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/5e903c020e4cd4ef65ec4b3ebcc0a1df9ab2c064f303e377
-          - "$ref": https://ns.adobe.com/xdm/context/profile-work-details
-          imsOrg: '{IMS_ORG}'
+          - $ref: https://ns.adobe.com/xdm/context/profile-test-profile
+          - $ref: "https://ns.adobe.com/{TENANT_ID}/mixins/e16d03cd4f0f1cd0f837ceada0aa478e"
+          - $ref: "https://ns.adobe.com/{TENANT_ID}/mixins/03a07059cad2a4d772385bcf8105750f"
+          - $ref: "https://ns.adobe.com/{TENANT_ID}/mixins/6287e6dfaf504f1eb47842492431255d"
+          - $ref: "https://ns.adobe.com/{TENANT_ID}/mixins/5a55c7ba8bfe66d1ec0fd5b7e6a2a280c45c6e3312c259ef"
+          - $ref: https://ns.adobe.com/xdm/mixins/profile-consents
+          - $ref: https://ns.adobe.com/xdm/common/external-source-system-audit-details
+          - $ref: https://ns.adobe.com/xdm/context/profile-person-details
+          - $ref: "https://ns.adobe.com/{TENANT_ID}/mixins/1e9576c98a5d2a67ac90da1a271f5eb2"
+          - $ref: https://ns.adobe.com/xdm/context/profile-privacy
+          - $ref: "https://ns.adobe.com/{TENANT_ID}/mixins/44850059caa530684c4507d0e01647e9"
+          - $ref: https://ns.adobe.com/xdm/mixins/profile/profile-loyalty-details
+          - $ref: "https://ns.adobe.com/{TENANT_ID}/mixins/d0b9284f0610076e97f57dfadf78b3de"
+          - $ref: https://ns.adobe.com/experience/campaign/profile-all
+          - $ref: https://ns.adobe.com/xdm/context/profile-personal-details
+          - $ref: "https://ns.adobe.com/{TENANT_ID}/mixins/811a7c6627d5af6680cdfebf81c101c2"
+          - $ref: https://ns.adobe.com/experience/profile-edgeregion
+          - $ref: https://ns.adobe.com/xdm/context/profile
+          - $ref: https://ns.adobe.com/xdm/context/identitymap
+          - $ref: https://ns.adobe.com/experience/profile/profile-all
+          - $ref: https://ns.adobe.com/xdm/context/profile-segmentation
+          - $ref: https://ns.adobe.com/xdm/context/profile-preferences-details
+          - $ref: "https://ns.adobe.com/{TENANT_ID}/mixins/5e903c020e4cd4ef65ec4b3ebcc0a1df9ab2c064f303e377"
+          - $ref: https://ns.adobe.com/xdm/context/profile-work-details
+          imsOrg: "{IMS_ORG}"
           meta:extends:
-          - https://ns.adobe.com/{TENANT_ID}/schemas/7c92ae0a47db946ba5d7d47b1cfbca4b
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/7c92ae0a47db946ba5d7d47b1cfbca4b"
           - https://ns.adobe.com/xdm/common/extensible
-          - https://ns.adobe.com/{TENANT_ID}/schemas/5d70026f5522fc60b3c81f6523b83c86
-          - https://ns.adobe.com/{TENANT_ID}/mixins/5a55c7ba8bfe66d1ec0fd5b7e6a2a280c45c6e3312c259ef
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/5d70026f5522fc60b3c81f6523b83c86"
+          - "https://ns.adobe.com/{TENANT_ID}/mixins/5a55c7ba8bfe66d1ec0fd5b7e6a2a280c45c6e3312c259ef"
           - https://ns.adobe.com/xdm/mixins/profile-consents
-          - https://ns.adobe.com/{TENANT_ID}/schemas/c447e8716f1d4598be9e36dcd64cd55a
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/c447e8716f1d4598be9e36dcd64cd55a"
           - https://ns.adobe.com/xdm/common/external-source-system-audit-details
-          - https://ns.adobe.com/{TENANT_ID}/mixins/d0b9284f0610076e97f57dfadf78b3de
-          - https://ns.adobe.com/{TENANT_ID}/schemas/653e53eb04341d09453c9b6a5fb43d1b4ca9526ec274856d
-          - https://ns.adobe.com/{TENANT_ID}/schemas/c65ddf08cf2d4a2fe94bd06113bf4bc4c855e12a936410d5
-          - https://ns.adobe.com/{TENANT_ID}/mixins/811a7c6627d5af6680cdfebf81c101c2
-          - https://ns.adobe.com/{TENANT_ID}/schemas/ea2208ffef6dc12851f938e54bc723f2b6aa1a7bcb9b9535
+          - "https://ns.adobe.com/{TENANT_ID}/mixins/d0b9284f0610076e97f57dfadf78b3de"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/653e53eb04341d09453c9b6a5fb43d1b4ca9526ec274856d"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/c65ddf08cf2d4a2fe94bd06113bf4bc4c855e12a936410d5"
+          - "https://ns.adobe.com/{TENANT_ID}/mixins/811a7c6627d5af6680cdfebf81c101c2"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/ea2208ffef6dc12851f938e54bc723f2b6aa1a7bcb9b9535"
           - https://ns.adobe.com/experience/profile/profile-all
           - https://ns.adobe.com/xdm/context/profile-work-details
-          - https://ns.adobe.com/{TENANT_ID}/schemas/a938858fbe085db9cc0d7b17ca7da28d
-          - https://ns.adobe.com/{TENANT_ID}/schemas/e5c13b941fc87d3614f742528e8c30693baae7c41af01fc2
-          - https://ns.adobe.com/{TENANT_ID}/schemas/b67de72ed55dcafec654ec9818eb55a4
-          - https://ns.adobe.com/{TENANT_ID}/schemas/e7bc97acfaf14832fd666cbd6b3629e1
-          - https://ns.adobe.com/{TENANT_ID}/schemas/afb2da1c042e4413de24f4096157c9f6a72cc43b57ee1a
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/a938858fbe085db9cc0d7b17ca7da28d"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/e5c13b941fc87d3614f742528e8c30693baae7c41af01fc2"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/b67de72ed55dcafec654ec9818eb55a4"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/e7bc97acfaf14832fd666cbd6b3629e1"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/afb2da1c042e4413de24f4096157c9f6a72cc43b57ee1a"
           - https://ns.adobe.com/experience/campaign/profile-all
           - https://ns.adobe.com/xdm/context/profile
           - https://ns.adobe.com/xdm/context/profile-segmentation
           - https://ns.adobe.com/xdm/context/profile-preferences-details
-          - https://ns.adobe.com/{TENANT_ID}/schemas/36966a17ce64bcee6544df170f7299759d3dce41c8cbee6
-          - https://ns.adobe.com/{TENANT_ID}/schemas/b29ba32d98a8b1f00388c6c6eceff4db6917fd174eab4c55
-          - https://ns.adobe.com/{TENANT_ID}/mixins/5e903c020e4cd4ef65ec4b3ebcc0a1df9ab2c064f303e377
-          - https://ns.adobe.com/{TENANT_ID}/schemas/456bdc7d1216fb96fa42495a449f39c2
-          - https://ns.adobe.com/{TENANT_ID}/schemas/579a2817c2342751afb9241015da9741
-          - https://ns.adobe.com/{TENANT_ID}/schemas/be9f753fc193a23baa8893bbe7679afe
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/36966a17ce64bcee6544df170f7299759d3dce41c8cbee6"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/b29ba32d98a8b1f00388c6c6eceff4db6917fd174eab4c55"
+          - "https://ns.adobe.com/{TENANT_ID}/mixins/5e903c020e4cd4ef65ec4b3ebcc0a1df9ab2c064f303e377"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/456bdc7d1216fb96fa42495a449f39c2"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/579a2817c2342751afb9241015da9741"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/be9f753fc193a23baa8893bbe7679afe"
           - https://ns.adobe.com/xdm/common/auditable
-          - https://ns.adobe.com/{TENANT_ID}/schemas/f09963a76904b524f6419a50c19dd4318061d82d8b04638
-          - https://ns.adobe.com/{TENANT_ID}/mixins/e16d03cd4f0f1cd0f837ceada0aa478e
-          - https://ns.adobe.com/{TENANT_ID}/schemas/b1e6dd903c29dc7aea408ecd1ed040f0c161df7961fc50b2
-          - https://ns.adobe.com/{TENANT_ID}/schemas/d29a200b5deb6cfb55d3b865ef627f33
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/f09963a76904b524f6419a50c19dd4318061d82d8b04638"
+          - "https://ns.adobe.com/{TENANT_ID}/mixins/e16d03cd4f0f1cd0f837ceada0aa478e"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/b1e6dd903c29dc7aea408ecd1ed040f0c161df7961fc50b2"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/d29a200b5deb6cfb55d3b865ef627f33"
           - https://ns.adobe.com/xdm/context/profile-person-details
           - https://ns.adobe.com/xdm/context/profile-privacy
-          - https://ns.adobe.com/{TENANT_ID}/mixins/44850059caa530684c4507d0e01647e9
-          - https://ns.adobe.com/{TENANT_ID}/schemas/e348088f36cb2dc90d14737de6832aa35c7a7f1a116e1dbe
+          - "https://ns.adobe.com/{TENANT_ID}/mixins/44850059caa530684c4507d0e01647e9"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/e348088f36cb2dc90d14737de6832aa35c7a7f1a116e1dbe"
           - https://ns.adobe.com/xdm/mixins/profile/profile-loyalty-details
           - https://ns.adobe.com/xdm/context/profile-personal-details
           - https://ns.adobe.com/xdm/data/record
           - https://ns.adobe.com/experience/profile-edgeregion
           - https://ns.adobe.com/xdm/context/identitymap
-          - https://ns.adobe.com/{TENANT_ID}/schemas/ebbbb87cb534798841d760ea2c5d861d
-          - https://ns.adobe.com/{TENANT_ID}/schemas/3494225dfbfb0d9ac346b00a1142c3a1c0751aff9dbbf5ef
-          - https://ns.adobe.com/{TENANT_ID}/schemas/6fd18629565e429e5379c77c2755618b
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/ebbbb87cb534798841d760ea2c5d861d"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/3494225dfbfb0d9ac346b00a1142c3a1c0751aff9dbbf5ef"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/6fd18629565e429e5379c77c2755618b"
           - https://ns.adobe.com/xdm/context/profile-test-profile
-          - https://ns.adobe.com/{TENANT_ID}/schemas/4fcf5778706905d53c138b1ed4d94c6c
-          - https://ns.adobe.com/{TENANT_ID}/mixins/03a07059cad2a4d772385bcf8105750f
-          - https://ns.adobe.com/{TENANT_ID}/mixins/6287e6dfaf504f1eb47842492431255d
-          - https://ns.adobe.com/{TENANT_ID}/schemas/ac95d88f11b47688ef2f24f55fe5f3a9a607bb2c4325e68d
-          - https://ns.adobe.com/{TENANT_ID}/schemas/70e3226d662a19800837b7dd7cfc3ef6
-          - https://ns.adobe.com/{TENANT_ID}/schemas/5df4f4cc39462136cbbead3481f878a878420025282a53b8
-          - https://ns.adobe.com/{TENANT_ID}/schemas/3a1859ec31ba93153050f92d981aec5d97b350d22cf960d5
-          - https://ns.adobe.com/{TENANT_ID}/mixins/1e9576c98a5d2a67ac90da1a271f5eb2
-          - https://ns.adobe.com/{TENANT_ID}/schemas/3d569c62921ac9371ad148afbaec3891547aca2a49575cef
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/4fcf5778706905d53c138b1ed4d94c6c"
+          - "https://ns.adobe.com/{TENANT_ID}/mixins/03a07059cad2a4d772385bcf8105750f"
+          - "https://ns.adobe.com/{TENANT_ID}/mixins/6287e6dfaf504f1eb47842492431255d"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/ac95d88f11b47688ef2f24f55fe5f3a9a607bb2c4325e68d"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/70e3226d662a19800837b7dd7cfc3ef6"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/5df4f4cc39462136cbbead3481f878a878420025282a53b8"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/3a1859ec31ba93153050f92d981aec5d97b350d22cf960d5"
+          - "https://ns.adobe.com/{TENANT_ID}/mixins/1e9576c98a5d2a67ac90da1a271f5eb2"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/3d569c62921ac9371ad148afbaec3891547aca2a49575cef"
           meta:xdmType: object
           meta:registryMetadata:
             eTag: e4655a460374dec4dd7c32d3075a4ffc8249146b4d9c6ae09682da51266a78da
             meta:globalLibVersion: 1.28.1
           meta:class: https://ns.adobe.com/xdm/context/profile
           meta:containerId: tenant
-        - "$id": https://ns.adobe.com/xdm/context/experienceevent__union
+        - $id: https://ns.adobe.com/xdm/context/experienceevent__union
           meta:altId: _xdm.context.experienceevent__union
           meta:resourceType: unions
-          version: '1.0'
+          version: "1.0"
           title: XDM ExperienceEvent
           type: object
-          description: An ExperienceEvent is a fact record of what occurred, including the
-            point in time and identity of the individual involved. ExperienceEvents can be
-            either explicit (directly observable human actions) or implicit (raised without
-            a direct human action) and are recorded without aggregation or interpretation.
-            They are critical for time-domain analytics as they allow for observation and
-            analysis of changes that occur in a given window of time and the comparison between
-            multiple windows of time to track trends.
+          description: "An ExperienceEvent is a fact record of what occurred, including\
+            \ the point in time and identity of the individual involved. ExperienceEvents\
+            \ can be either explicit (directly observable human actions) or implicit\
+            \ (raised without a direct human action) and are recorded without aggregation\
+            \ or interpretation. They are critical for time-domain analytics as they\
+            \ allow for observation and analysis of changes that occur in a given\
+            \ window of time and the comparison between multiple windows of time to\
+            \ track trends."
           allOf:
-          - "$ref": https://ns.adobe.com/experience/journeyOrchestration/stepEvents/journeyStepEventDataFetchFields
-          - "$ref": https://ns.adobe.com/experience/journeyOrchestration/stepEvents/journeyStepEventCommonFields
-          - "$ref": https://ns.adobe.com/xdm/context/experienceevent-commerce
-          - "$ref": https://ns.adobe.com/xdm/context/experienceevent-web
-          - "$ref": https://ns.adobe.com/xdm/context/experienceevent-marketing
-          - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/ae0c9aadd004dbd2c438077f500df26781c414e60bbf4a54
-          - "$ref": https://ns.adobe.com/xdm/context/experienceevent-environment-details
-          - "$ref": https://ns.adobe.com/xdm/context/experienceevent
-          - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/1a7a5de2a84c6aacbf86c8d282a891a0
-          - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/7b5217dec3313f1a2a067ff5a29066c0
-          - "$ref": https://ns.adobe.com/xdm/context/identitymap
-          - "$ref": https://ns.adobe.com/experience/journeyOrchestration/stepEvents/journeyStepEventActionExecutionFields
-          - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/90e1950ab23ab1e71273c2aab0bbf5e978d5d9a6a1cc5bab
-          - "$ref": https://ns.adobe.com/experience/campaign/orchestration/eventid
-          imsOrg: '{IMS_ORG}'
+          - $ref: https://ns.adobe.com/experience/journeyOrchestration/stepEvents/journeyStepEventDataFetchFields
+          - $ref: https://ns.adobe.com/experience/journeyOrchestration/stepEvents/journeyStepEventCommonFields
+          - $ref: https://ns.adobe.com/xdm/context/experienceevent-commerce
+          - $ref: https://ns.adobe.com/xdm/context/experienceevent-web
+          - $ref: https://ns.adobe.com/xdm/context/experienceevent-marketing
+          - $ref: "https://ns.adobe.com/{TENANT_ID}/mixins/ae0c9aadd004dbd2c438077f500df26781c414e60bbf4a54"
+          - $ref: https://ns.adobe.com/xdm/context/experienceevent-environment-details
+          - $ref: https://ns.adobe.com/xdm/context/experienceevent
+          - $ref: "https://ns.adobe.com/{TENANT_ID}/mixins/1a7a5de2a84c6aacbf86c8d282a891a0"
+          - $ref: "https://ns.adobe.com/{TENANT_ID}/mixins/7b5217dec3313f1a2a067ff5a29066c0"
+          - $ref: https://ns.adobe.com/xdm/context/identitymap
+          - $ref: https://ns.adobe.com/experience/journeyOrchestration/stepEvents/journeyStepEventActionExecutionFields
+          - $ref: "https://ns.adobe.com/{TENANT_ID}/mixins/90e1950ab23ab1e71273c2aab0bbf5e978d5d9a6a1cc5bab"
+          - $ref: https://ns.adobe.com/experience/campaign/orchestration/eventid
+          imsOrg: "{IMS_ORG}"
           meta:extends:
           - https://ns.adobe.com/xdm/data/time-series
-          - https://ns.adobe.com/{TENANT_ID}/schemas/cece2f127694fc27e9233480018790b3ceb4f3e50a55cf80
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/cece2f127694fc27e9233480018790b3ceb4f3e50a55cf80"
           - https://ns.adobe.com/experience/journeyOrchestration/stepEvents/journeyStepEventDataFetchFields
           - https://ns.adobe.com/experience/journeyOrchestration/stepEvents/journeyStepEventCommonFields
-          - https://ns.adobe.com/{TENANT_ID}/schemas/3423b2c60609e0418ded3962fcc47ed8
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/3423b2c60609e0418ded3962fcc47ed8"
           - https://ns.adobe.com/xdm/context/experienceevent-commerce
           - https://ns.adobe.com/xdm/common/extensible
-          - https://ns.adobe.com/{TENANT_ID}/schemas/f8fe82b4e8bd1ee85db5ad0172664957ef8c9931245cb7e6
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/f8fe82b4e8bd1ee85db5ad0172664957ef8c9931245cb7e6"
           - https://ns.adobe.com/xdm/context/experienceevent-web
           - https://ns.adobe.com/xdm/context/experienceevent-marketing
-          - https://ns.adobe.com/{TENANT_ID}/mixins/ae0c9aadd004dbd2c438077f500df26781c414e60bbf4a54
+          - "https://ns.adobe.com/{TENANT_ID}/mixins/ae0c9aadd004dbd2c438077f500df26781c414e60bbf4a54"
           - https://ns.adobe.com/xdm/context/experienceevent-environment-details
           - https://ns.adobe.com/xdm/context/experienceevent
-          - https://ns.adobe.com/{TENANT_ID}/mixins/1a7a5de2a84c6aacbf86c8d282a891a0
-          - https://ns.adobe.com/{TENANT_ID}/schemas/4425853159dc7e494b8971a4de80daf97571bd5c30d743cf
-          - https://ns.adobe.com/{TENANT_ID}/mixins/7b5217dec3313f1a2a067ff5a29066c0
+          - "https://ns.adobe.com/{TENANT_ID}/mixins/1a7a5de2a84c6aacbf86c8d282a891a0"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/4425853159dc7e494b8971a4de80daf97571bd5c30d743cf"
+          - "https://ns.adobe.com/{TENANT_ID}/mixins/7b5217dec3313f1a2a067ff5a29066c0"
           - https://ns.adobe.com/xdm/context/identitymap
           - https://ns.adobe.com/experience/journeyOrchestration/stepEvents/journeyStepEventActionExecutionFields
-          - https://ns.adobe.com/{TENANT_ID}/mixins/90e1950ab23ab1e71273c2aab0bbf5e978d5d9a6a1cc5bab
-          - https://ns.adobe.com/{TENANT_ID}/schemas/5d4a826626bbff36134b24b92dd61f83
-          - https://ns.adobe.com/{TENANT_ID}/schemas/bacec2361d131bf03211cf3c2372673f
-          - https://ns.adobe.com/{TENANT_ID}/schemas/43f12f6de7d667db7f11f35e6af43802
+          - "https://ns.adobe.com/{TENANT_ID}/mixins/90e1950ab23ab1e71273c2aab0bbf5e978d5d9a6a1cc5bab"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/5d4a826626bbff36134b24b92dd61f83"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/bacec2361d131bf03211cf3c2372673f"
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/43f12f6de7d667db7f11f35e6af43802"
           - https://ns.adobe.com/experience/campaign/orchestration/eventid
           meta:xdmType: object
           meta:registryMetadata:
@@ -2234,21 +4018,22 @@ definitions:
             meta:globalLibVersion: 1.28.1
           meta:class: https://ns.adobe.com/xdm/context/experienceevent
           meta:containerId: tenant
-        - "$id": https://ns.adobe.com/xdm/context/segmentdefinition__union
+        - $id: https://ns.adobe.com/xdm/context/segmentdefinition__union
           meta:altId: _xdm.context.segmentdefinition__union
           meta:resourceType: unions
-          version: '1.0'
+          version: "1.0"
           title: Segment definition
           type: object
-          description: This is the base class for a segment definition which includes required
-            fields like identity of a segment and name of segment. Segment definitions coming
-            from various system can use this class to build Segment Definition XDM schema.
+          description: This is the base class for a segment definition which includes
+            required fields like identity of a segment and name of segment. Segment
+            definitions coming from various system can use this class to build Segment
+            Definition XDM schema.
           allOf:
-          - "$ref": https://ns.adobe.com/xdm/context/identitymap
-          - "$ref": https://ns.adobe.com/xdm/context/segmentdefinition
-          imsOrg: '{IMS_ORG}'
+          - $ref: https://ns.adobe.com/xdm/context/identitymap
+          - $ref: https://ns.adobe.com/xdm/context/segmentdefinition
+          imsOrg: "{IMS_ORG}"
           meta:extends:
-          - https://ns.adobe.com/{TENANT_ID}/schemas/23255099a00826c31bbad8fa9519d3d513d5171bf2b787a2
+          - "https://ns.adobe.com/{TENANT_ID}/schemas/23255099a00826c31bbad8fa9519d3d513d5171bf2b787a2"
           - https://ns.adobe.com/xdm/common/auditable
           - https://ns.adobe.com/xdm/data/record
           - https://ns.adobe.com/xdm/context/identitymap
@@ -2259,279 +4044,196 @@ definitions:
             meta:globalLibVersion: 1.28.1
           meta:class: https://ns.adobe.com/xdm/context/segmentdefinition
           meta:containerId: tenant
-  createSchema:
-    type: object
-    properties:
-      type:
-        type: string
-        description: The JSON Schema data type for the resource. Must be set to `object`.
-        example: object
-      title:
-        type: string
-        description: A title for the schema.
-        example: New Schema
-      description:
-        type: string
-        description: A description for the schema.
-        example: Description of the new schema.
-      allOf:
-        type: array
-        description: Lists the class and/or field groups whose fields the schema implements. Each object contains a single property (`$ref`) whose value represents the `$id` of the class or field group the new schema will implement. One class must be provided, with zero or more additional field groups.
-        items:
-          type: object
-          properties:
-            "$ref":
-              type: string
-              description: The `$id` of the class or field group whose fields will be utilized by the schema.
-              example: https://ns.adobe.com/xdm/context/profile
-    required:
-      - type
-      - title
-      - description
+    createSchema:
+      required:
       - allOf
-  updateSchemaResponse:
-    allOf:
-      - $ref: '#/definitions/singleSchemaResponse'
-      - properties:
-          version:
-            example: "1.1"
-  createSchemaResponse:
-    allOf:
-      - $ref: '#/definitions/singleSchemaResponse'
-    example:
-      $id: https://ns.adobe.com/{TENANT_ID}/schemas/e417987b8b861d373ef4d0fe8ad61fa4c15fa0274332c8af
-      meta:altId: _{TENANT_ID}.schemas.e417987b8b861d373ef4d0fe8ad61fa4c15fa0274332c8af
-      meta:resourceType: schemas
-      version: '1.0'
-      title: New Schema
+      - description
+      - title
+      - type
       type: object
-      description: Description of the new schema.
+      properties:
+        type:
+          type: string
+          description: The JSON Schema data type for the resource. Must be set to
+            `object`.
+          example: object
+        title:
+          type: string
+          description: A title for the schema.
+          example: New Schema
+        description:
+          type: string
+          description: A description for the schema.
+          example: Description of the new schema.
+        allOf:
+          type: array
+          description: "Lists the class and/or field groups whose fields the schema\
+            \ implements. Each object contains a single property (`$ref`) whose value\
+            \ represents the `$id` of the class or field group the new schema will\
+            \ implement. One class must be provided, with zero or more additional\
+            \ field groups."
+          items:
+            type: object
+            properties:
+              $ref:
+                type: string
+                description: The `$id` of the class or field group whose fields will
+                  be utilized by the schema.
+                example: https://ns.adobe.com/xdm/context/profile
+    updateSchemaResponse:
       allOf:
-      - "$ref": https://ns.adobe.com/xdm/context/profile
-        type: object
-        meta:xdmType: object
-      refs:
-      - https://ns.adobe.com/xdm/context/profile
-      imsOrg: "{IMS_ORG}"
-      meta:extensible: false
-      meta:abstract: false
-      meta:extends:
-      - https://ns.adobe.com/xdm/common/auditable
-      - https://ns.adobe.com/xdm/data/record
-      - https://ns.adobe.com/xdm/context/profile
-      meta:xdmType: object
-      meta:registryMetadata:
-        repo:createdDate: 1635537329990
-        repo:lastModifiedDate: 1635537329990
-        xdm:createdClientId: "{CLIENT_ID}"
-        xdm:lastModifiedClientId: "{CLIENT_ID}"
-        xdm:createdUserId: "{USER_ID}"
-        xdm:lastModifiedUserId: "{USER_ID}"
-        eTag: 022afad00319b928238bcf88e20cc8e1fbdddfee6663925041004a49bdc2abeb
-        meta:globalLibVersion: 1.27.4
-      meta:class: https://ns.adobe.com/xdm/context/profile
-      meta:containerId: tenant
-      meta:sandboxId: 28e74200-e3de-11e9-8f5d-7f27416c5f0d
-      meta:sandboxType: production
-      meta:tenantNamespace: _{TENANT_ID}
-
-  lookupResourceCore:
-    type: object
-    properties:
-      $id:
-        type: string
-        description: The URI ID of the XDM resource.
-        example: https://ns.adobe.com/{TENANT_ID}/schemas/d4ad4b8463a67f6755f2aabbeb9e02c7
-      meta:altId:
-        type: string
-        description: An alternate dot-notation ID for the XDM resource.
-        example: _{TENANT_ID}.schemas.d4ad4b8463a67f6755f2aabbeb9e02c7
-      meta:resourceType:
-        type: string
-        description: The type of XDM resource.
-        example: schemas
-      version:
-        type: string
-        description: The current version of the resource.
-        example: 1.4
-      title:
-        type: string
-        description: The title of the resource.
-        example: Hotels
-      type:
-        type: string
-        description: The JSON Schema element type that represents the XDM resource (typically `object`).
-        example: object
-      description:
-        type: string
-        description: A description for the resource.
-  lookupResourceWithDefinitions:
-    allOf:
-      - $ref: '#/definitions/lookupResourceCore'
-      - properties:
+      - $ref: '#/components/schemas/singleSchemaResponse'
+      - type: object
+        properties:
+          version:
+            type: object
+            example: "1.1"
+    createSchemaResponse:
+      allOf:
+      - $ref: '#/components/schemas/singleSchemaResponse'
+    lookupResourceCore:
+      type: object
+      properties:
+        $id:
+          type: string
+          description: The URI ID of the XDM resource.
+          example: "https://ns.adobe.com/{TENANT_ID}/schemas/d4ad4b8463a67f6755f2aabbeb9e02c7"
+        meta:altId:
+          type: string
+          description: An alternate dot-notation ID for the XDM resource.
+          example: "_{TENANT_ID}.schemas.d4ad4b8463a67f6755f2aabbeb9e02c7"
+        meta:resourceType:
+          type: string
+          description: The type of XDM resource.
+          example: schemas
+        version:
+          type: string
+          description: The current version of the resource.
+          example: "1.4"
+        title:
+          type: string
+          description: The title of the resource.
+          example: Hotels
+        type:
+          type: string
+          description: The JSON Schema element type that represents the XDM resource
+            (typically `object`).
+          example: object
+        description:
+          type: string
+          description: A description for the resource.
+    lookupResourceWithDefinitions:
+      allOf:
+      - $ref: '#/components/schemas/lookupResourceCore'
+      - type: object
+        properties:
           definitions:
             type: object
-            description: Contains definitions for the unique attributes provided by the resource.
+            properties: {}
+            description: Contains definitions for the unique attributes provided by
+              the resource.
           allOf:
             type: array
-            description: A list of objects that refer to the common definitions and fields that the resource inherits.
+            description: A list of objects that refer to the common definitions and
+              fields that the resource inherits.
             items:
-              $ref: '#/definitions/allOfRef'
+              $ref: '#/components/schemas/allOfRef'
           meta:extensible:
             type: boolean
             description: Indicates whether this resource is extensible or not.
           meta:abstract:
             type: boolean
             description: Indicates whether this resource is abstract or not.
-  singleDataTypeResponse:
-    allOf:
-      - $ref: '#/definitions/lookupResourceWithDefinitions'
-      - properties:
+    singleDataTypeResponse:
+      allOf:
+      - $ref: '#/components/schemas/lookupResourceWithDefinitions'
+      - type: object
+        properties:
           meta:extends:
             type: array
-            description: An array that contains the `$id` values of the XDM resources this data type extends.
+            description: An array that contains the `$id` values of the XDM resources
+              this data type extends.
             items:
               type: string
               description: The `$id` of the resource this data type extends.
-      - $ref: '#/definitions/xdmTypeToSchema'
-      - $ref: '#/definitions/metaRegistryMetadata'
-
-  singleFieldGroupResponse:
-    allOf:
-      - $ref: '#/definitions/lookupResourceWithDefinitions'
-      - properties:
+      - $ref: '#/components/schemas/xdmTypeToSchema'
+      - $ref: '#/components/schemas/metaRegistryMetadata'
+    singleFieldGroupResponse:
+      allOf:
+      - $ref: '#/components/schemas/lookupResourceWithDefinitions'
+      - type: object
+        properties:
           meta:intendedToExtend:
             type: array
-            description: An array that contains the `$id` of the class this field group is compatible with.
+            description: An array that contains the `$id` of the class this field
+              group is compatible with.
             items:
               type: string
               description: The `$id` of the class this field group is compatible with.
-      - $ref: '#/definitions/xdmTypeToSchema'
-      - $ref: '#/definitions/metaRegistryMetadata'
-      - properties:
+      - $ref: '#/components/schemas/xdmTypeToSchema'
+      - $ref: '#/components/schemas/metaRegistryMetadata'
+      - type: object
+        properties:
           meta:tags:
             type: object
-            description: (For `global` field groups only) Describes various Adobe-managed categorization tags for the field group.
+            properties: {}
+            description: (For `global` field groups only) Describes various Adobe-managed
+              categorization tags for the field group.
           meta:createdDate:
             type: object
-            description: (For `global` field groups only) A timestamp of when the global field group was released.
-  singleBehaviorResponse:
-    allOf:
-      - $ref: '#/definitions/lookupResourceWithDefinitions'
-      - $ref: '#/definitions/xdmTypeToSchema'
-      - $ref: '#/definitions/metaRegistryMetadata'
-          
-    example:
-      $id: 'https://ns.adobe.com/xdm/data/record'
-      'meta:altId': _xdm.data.record
-      'meta:resourceType': behaviors
-      version: 1.16.4
-      title: Record Schema
-      type: object
-      description: Used to indicate the behavior of record data semantic when composed into data schemas.
-      definitions:
-        record:
-          properties:
-            _id:
-              title: Identifier
-              type: string
-              format: uri-reference
-              description: A unique identifier for the record.
-              'meta:xdmType': string
-              'meta:xdmField': '@id'
-      'allOf':
-        - '$ref': '#/definitions/record'
-          type: object
-          'meta:xdmType': object
-        - '$ref': 'https://ns.adobe.com/xdm/common/extensible%23/definitions/@context'
-          type: object
-          'meta:xdmType': object
-      'meta:extensible': true
-      'meta:abstract': true
-      'meta:xdmType': object
-      'meta:status': stable
-      $schema: 'http://json-schema.org/draft-06/schema#'
-      'meta:registryMetadata':
-        'repo:createdDate': 1606266789446
-        'repo:lastModifiedDate': 1606266789446
-        eTag: 2cc114a54949a9668fe2ad046ccece59192e1bfa28f14e5ac7c893acb7820ba2
-        'meta:globalLibVersion': 1.16.4
-  metaRegistryMetadata:
-    type: object
-    properties:
-      meta:registryMetadata:
-        $ref: '#/definitions/registryMetadata'
-  xdmTypeToSchema:
-    type: object
-    properties:
-      meta:xdmType:
-        type: string
-        description: The XDM resource type (typically `object`).
-      meta:status:
-        type: string
-        description: (For `global` resources only) The status of the resource.
-      $schema:
-        type: string
-        description: The JSON schema definition that this resource is based on.
-  singleClassResponse:
-    allOf:
-      - $ref: '#/definitions/singleBehaviorResponse'
-    example:
-      "$id": https://ns.adobe.com/experience/journeyOrchestration/stepEvents/journey
-      meta:altId: _experience.journeyOrchestration.stepEvents.journey
-      meta:resourceType: classes
-      version: 1.27.4
-      title: Journey Orchestration Class
-      type: object
-      description: A Record based Journey class for Journey orchestration contains common
-        journey fields
-      definitions:
-        journeyClass:
-          properties: {}
+            properties: {}
+            description: (For `global` field groups only) A timestamp of when the
+              global field group was released.
+    singleBehaviorResponse:
       allOf:
-      - "$ref": https://ns.adobe.com/xdm/data/record
-        type: object
-        meta:xdmType: object
-      - "$ref": "#/definitions/journeyClass"
-        type: object
-        meta:xdmType: object
-      auditable: true
-      meta:extensible: true
-      meta:abstract: true
-      meta:extends:
-      - https://ns.adobe.com/xdm/data/record
-      meta:xdmType: object
-      meta:status: stable
-      "$schema": http://json-schema.org/draft-06/schema#
-      meta:registryMetadata:
-        repo:createdDate: 1635361814823
-        repo:lastModifiedDate: 1635361814823
-        eTag: 351d2457ea40413a486ed6f328eb7f9384e63ded16019c7223e2586badf5a60a
-        meta:globalLibVersion: 1.27.4
-  allOfRef:
-    type: object
-    properties:
-      '$ref':
-        type: string
-        description: The `$id` of the XDM resource.
-      type:
-        type: string
-        description: The resource type (typically `object`).
-      'meta:xdmType':
-        type: string
-        description: The XDM resource type (typically `object`).
-  singleSchemaResponse:
-    type: object
-    allOf:
-      - $ref: '#/definitions/lookupResourceCore'
-      - properties:
+      - $ref: '#/components/schemas/lookupResourceWithDefinitions'
+      - $ref: '#/components/schemas/xdmTypeToSchema'
+      - $ref: '#/components/schemas/metaRegistryMetadata'
+    metaRegistryMetadata:
+      type: object
+      properties:
+        meta:registryMetadata:
+          $ref: '#/components/schemas/registryMetadata'
+    xdmTypeToSchema:
+      type: object
+      properties:
+        meta:xdmType:
+          type: string
+          description: The XDM resource type (typically `object`).
+        meta:status:
+          type: string
+          description: (For `global` resources only) The status of the resource.
+        $schema:
+          type: string
+          description: The JSON schema definition that this resource is based on.
+    singleClassResponse:
+      allOf:
+      - $ref: '#/components/schemas/singleBehaviorResponse'
+    allOfRef:
+      type: object
+      properties:
+        $ref:
+          type: string
+          description: The `$id` of the XDM resource.
+        type:
+          type: string
+          description: The resource type (typically `object`).
+        meta:xdmType:
+          type: string
+          description: The XDM resource type (typically `object`).
+    singleSchemaResponse:
+      allOf:
+      - $ref: '#/components/schemas/lookupResourceCore'
+      - type: object
+        properties:
           allOf:
             type: array
-            description: A list of objects that refer to other classes, field groups, or data types whose properties are inherited by this XDM resource.
+            description: "A list of objects that refer to other classes, field groups,\
+              \ or data types whose properties are inherited by this XDM resource."
             items:
               type: object
               properties:
-                "$ref":
+                $ref:
                   type: string
                   description: The URI `$id` of the referenced XDM resource.
           imsOrg:
@@ -2545,254 +4247,123 @@ definitions:
             description: Indicates whether this is an abstract resource.
           meta:extends:
             type: array
-            description: A list of URI `$id`s for the XDM objects that this resource extends. 
+            description: A list of URI `$id`s for the XDM objects that this resource
+              extends.
             items:
               type: string
           meta:xdmType:
             type: string
-            description: The type of JSON Schema element that the XDM resource represents (typically `object`).
+            description: The type of JSON Schema element that the XDM resource represents
+              (typically `object`).
           meta:registryMetadata:
-            $ref: '#/definitions/registryMetadata'
-  metaClass:
-    type: object
-    properties:
-      meta:class:
-        type: string
-        description: The URI `$id` of the class that the schema is based on.
-  resourceContainers:
-    type: object
-    properties:
-      meta:containerId:
-        type: string
-        description: The container for the schema, either `global` or `tenant`.
-      meta:sandboxId:
-        type: string
-        description: The ID of the Platform sandbox that contains the schema.
-      meta:sandboxType:
-        type: string
-        description: The type of Platform sandbox that contains the schema, either `production` or `development`.
-  metaTenantNamespace:
-    type: object
-    properties:
-      meta:tenantNamespace:
-        type: string
-        description: "The namespace that all custom fields that the schema employs can be found under. Takes the form of your organization's tenant ID prepended with an underscore: `_{TENANT_ID}`."
-  lookupSchemaResponse:
-    allOf:
-      - $ref: '#/definitions/singleSchemaResponse'
-      - $ref: '#/definitions/metaClass'
-      - $ref: '#/definitions/resourceContainers'
-      - $ref: '#/definitions/metaTenantNamespace'
-    example:
-      $id: https://ns.adobe.com/{TENANT_ID}/schemas/d4ad4b8463a67f6755f2aabbeb9e02c7
-      meta:altId: _{TENANT_ID}.schemas.d4ad4b8463a67f6755f2aabbeb9e02c7
-      meta:resourceType: schemas
-      version: '1.4'
-      title: Hotels
+            $ref: '#/components/schemas/registryMetadata'
+    metaClass:
       type: object
-      description: Schema for hotels.
+      properties:
+        meta:class:
+          type: string
+          description: The URI `$id` of the class that the schema is based on.
+    resourceContainers:
+      type: object
+      properties:
+        meta:containerId:
+          type: string
+          description: "The container for the schema, either `global` or `tenant`."
+        meta:sandboxId:
+          type: string
+          description: The ID of the Platform sandbox that contains the schema.
+        meta:sandboxType:
+          type: string
+          description: "The type of Platform sandbox that contains the schema, either\
+            \ `production` or `development`."
+    metaTenantNamespace:
+      type: object
+      properties:
+        meta:tenantNamespace:
+          type: string
+          description: "The namespace that all custom fields that the schema employs\
+            \ can be found under. Takes the form of your organization's tenant ID\
+            \ prepended with an underscore: `_{TENANT_ID}`."
+    lookupSchemaResponse:
       allOf:
-      - "$ref": https://ns.adobe.com/xdm/context/profile
-      - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/a5f8594ef47312543ee8d7437f934fd8
-      imsOrg: "{IMS_ORG}"
-      meta:extensible: false
-      meta:abstract: false
-      meta:extends:
-      - https://ns.adobe.com/xdm/context/profile
-      - https://ns.adobe.com/xdm/data/record
-      - https://ns.adobe.com/xdm/context/identitymap
-      - https://ns.adobe.com/xdm/common/extensible
-      - https://ns.adobe.com/xdm/common/auditable
-      - https://ns.adobe.com/{TENANT_ID}/mixins/a5f8594ef47312543ee8d7437f934fd8
-      meta:xdmType: object
-      meta:registryMetadata:
-        repo:createdDate: 1570222174191
-        repo:lastModifiedDate: 1574113291149
-        xdm:createdClientId: "{CLIENT_ID}"
-        xdm:lastModifiedClientId: "{CLIENT_ID}"
-        xdm:createdUserId: "{USER_ID}"
-        xdm:lastModifiedUserId: "{USER_ID}"
-        eTag: e6717738681f663237572053aa02cb3a656ed02847e3361071db4d405e52357d
-        meta:globalLibVersion: 1.27.4
-      meta:class: https://ns.adobe.com/xdm/context/profile
-      meta:containerId: tenant
-      meta:sandboxId: 28e74200-e3de-11e9-8f5d-7f27416c5f0d
-      meta:sandboxType: production
-      meta:tenantNamespace: _{TENANT_ID}
-  registryMetadata:
-    type: object
-    description: Contains registry-specific metadata about the XDM resource.
-    properties:
-      repo:createdDate:
-        type: integer
-        description: A Unix timestamp of when the resource was created.
-      repo:lastModifiedDate:
-        type: integer
-        description: A Unix timestamp of when the resource was last modified.
-      xdm:createdClientId:
-        type: string
-        description: The ID of the client that created the resource.
-      xdm:lastModifiedClientId:
-        type: string
-        description: The ID of the client that last modified the resource.
-      xdm:createdUserId:
-        type: string
-        description: The ID of the user that created the resource.
-      xdm:lastModifiedUserId:
-        type: string
-        description: The ID of the user that last modified the resource.
-      etag:
-        type: string
-        description: An HTTP entity tag (ETag) for the resource.
-      meta:globalLibVersion:
-        type: string
-        description: The current global library version of the resource.
-      meta:usageCount:
-        type: integer
-        description: The number of instances where this resource is referenced by other XDM resources.
-  lookupUnionResponse:
-    allOf:
-      - $ref: '#/definitions/unionBasic'
-      - properties:
+      - $ref: '#/components/schemas/singleSchemaResponse'
+      - $ref: '#/components/schemas/metaClass'
+      - $ref: '#/components/schemas/resourceContainers'
+      - $ref: '#/components/schemas/metaTenantNamespace'
+    registryMetadata:
+      type: object
+      properties:
+        repo:createdDate:
+          type: integer
+          description: A Unix timestamp of when the resource was created.
+        repo:lastModifiedDate:
+          type: integer
+          description: A Unix timestamp of when the resource was last modified.
+        xdm:createdClientId:
+          type: string
+          description: The ID of the client that created the resource.
+        xdm:lastModifiedClientId:
+          type: string
+          description: The ID of the client that last modified the resource.
+        xdm:createdUserId:
+          type: string
+          description: The ID of the user that created the resource.
+        xdm:lastModifiedUserId:
+          type: string
+          description: The ID of the user that last modified the resource.
+        etag:
+          type: string
+          description: An HTTP entity tag (ETag) for the resource.
+        meta:globalLibVersion:
+          type: string
+          description: The current global library version of the resource.
+        meta:usageCount:
+          type: integer
+          description: The number of instances where this resource is referenced by
+            other XDM resources.
+      description: Contains registry-specific metadata about the XDM resource.
+    lookupUnionResponse:
+      allOf:
+      - $ref: '#/components/schemas/unionBasic'
+      - type: object
+        properties:
           meta:sandboxId:
             type: string
             description: The ID of the sandbox this union is contained in.
           meta:sandboxType:
             type: string
-            description: The type of sandbox this union is contained in, either `production` or `development`.
-    example:
-      "$id": https://ns.adobe.com/xdm/context/profile__union
-      meta:altId: _xdm.context.profile__union
-      meta:resourceType: unions
-      version: '1.0'
-      title: XDM Individual Profile
-      type: object
-      description: An XDM Individual Profile forms a singular representation of the attributes
-        and interests of both identified and partially-identified individuals. Less-identified
-        profiles may contain only anonymous behavioral signals, such as browser cookies,
-        while highly-identified profiles may contain detailed personal information such
-        as name, date of birth, location, and email address. As a profile grows, it becomes
-        a robust repository of personal information, identification information, contact
-        details, and communication preferences for an individual.
+            description: "The type of sandbox this union is contained in, either `production`\
+              \ or `development`."
+    unionBasic:
       allOf:
-      - {}
-      - "$ref": https://ns.adobe.com/xdm/context/profile-test-profile
-      - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/e16d03cd4f0f1cd0f837ceada0aa478e
-      - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/03a07059cad2a4d772385bcf8105750f
-      - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/6287e6dfaf504f1eb47842492431255d
-      - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/5a55c7ba8bfe66d1ec0fd5b7e6a2a280c45c6e3312c259ef
-      - "$ref": https://ns.adobe.com/xdm/mixins/profile-consents
-      - "$ref": https://ns.adobe.com/xdm/common/external-source-system-audit-details
-      - "$ref": https://ns.adobe.com/xdm/context/profile-person-details
-      - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/1e9576c98a5d2a67ac90da1a271f5eb2
-      - "$ref": https://ns.adobe.com/xdm/context/profile-privacy
-      - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/44850059caa530684c4507d0e01647e9
-      - "$ref": https://ns.adobe.com/xdm/mixins/profile/profile-loyalty-details
-      - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/d0b9284f0610076e97f57dfadf78b3de
-      - "$ref": https://ns.adobe.com/experience/campaign/profile-all
-      - "$ref": https://ns.adobe.com/xdm/context/profile-personal-details
-      - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/811a7c6627d5af6680cdfebf81c101c2
-      - "$ref": https://ns.adobe.com/experience/profile-edgeregion
-      - "$ref": https://ns.adobe.com/xdm/context/profile
-      - "$ref": https://ns.adobe.com/xdm/context/identitymap
-      - "$ref": https://ns.adobe.com/experience/profile/profile-all
-      - "$ref": https://ns.adobe.com/xdm/context/profile-segmentation
-      - "$ref": https://ns.adobe.com/xdm/context/profile-preferences-details
-      - "$ref": https://ns.adobe.com/{TENANT_ID}/mixins/5e903c020e4cd4ef65ec4b3ebcc0a1df9ab2c064f303e377
-      - "$ref": https://ns.adobe.com/xdm/context/profile-work-details
-      imsOrg: '{IMS_ORG}'
-      meta:extends:
-      - https://ns.adobe.com/{TENANT_ID}/schemas/7c92ae0a47db946ba5d7d47b1cfbca4b
-      - https://ns.adobe.com/xdm/common/extensible
-      - https://ns.adobe.com/{TENANT_ID}/schemas/5d70026f5522fc60b3c81f6523b83c86
-      - https://ns.adobe.com/{TENANT_ID}/mixins/5a55c7ba8bfe66d1ec0fd5b7e6a2a280c45c6e3312c259ef
-      - https://ns.adobe.com/xdm/mixins/profile-consents
-      - https://ns.adobe.com/{TENANT_ID}/schemas/c447e8716f1d4598be9e36dcd64cd55a
-      - https://ns.adobe.com/xdm/common/external-source-system-audit-details
-      - https://ns.adobe.com/{TENANT_ID}/mixins/d0b9284f0610076e97f57dfadf78b3de
-      - https://ns.adobe.com/{TENANT_ID}/schemas/653e53eb04341d09453c9b6a5fb43d1b4ca9526ec274856d
-      - https://ns.adobe.com/{TENANT_ID}/schemas/c65ddf08cf2d4a2fe94bd06113bf4bc4c855e12a936410d5
-      - https://ns.adobe.com/{TENANT_ID}/mixins/811a7c6627d5af6680cdfebf81c101c2
-      - https://ns.adobe.com/{TENANT_ID}/schemas/ea2208ffef6dc12851f938e54bc723f2b6aa1a7bcb9b9535
-      - https://ns.adobe.com/experience/profile/profile-all
-      - https://ns.adobe.com/xdm/context/profile-work-details
-      - https://ns.adobe.com/{TENANT_ID}/schemas/a938858fbe085db9cc0d7b17ca7da28d
-      - https://ns.adobe.com/{TENANT_ID}/schemas/e5c13b941fc87d3614f742528e8c30693baae7c41af01fc2
-      - https://ns.adobe.com/{TENANT_ID}/schemas/b67de72ed55dcafec654ec9818eb55a4
-      - https://ns.adobe.com/{TENANT_ID}/schemas/e7bc97acfaf14832fd666cbd6b3629e1
-      - https://ns.adobe.com/{TENANT_ID}/schemas/afb2da1c042e4413de24f4096157c9f6a72cc43b57ee1a
-      - https://ns.adobe.com/experience/campaign/profile-all
-      - https://ns.adobe.com/xdm/context/profile
-      - https://ns.adobe.com/xdm/context/profile-segmentation
-      - https://ns.adobe.com/xdm/context/profile-preferences-details
-      - https://ns.adobe.com/{TENANT_ID}/schemas/36966a17ce64bcee6544df170f7299759d3dce41c8cbee6
-      - https://ns.adobe.com/{TENANT_ID}/schemas/b29ba32d98a8b1f00388c6c6eceff4db6917fd174eab4c55
-      - https://ns.adobe.com/{TENANT_ID}/mixins/5e903c020e4cd4ef65ec4b3ebcc0a1df9ab2c064f303e377
-      - https://ns.adobe.com/{TENANT_ID}/schemas/456bdc7d1216fb96fa42495a449f39c2
-      - https://ns.adobe.com/{TENANT_ID}/schemas/579a2817c2342751afb9241015da9741
-      - https://ns.adobe.com/{TENANT_ID}/schemas/be9f753fc193a23baa8893bbe7679afe
-      - https://ns.adobe.com/xdm/common/auditable
-      - https://ns.adobe.com/{TENANT_ID}/schemas/f09963a76904b524f6419a50c19dd4318061d82d8b04638
-      - https://ns.adobe.com/{TENANT_ID}/mixins/e16d03cd4f0f1cd0f837ceada0aa478e
-      - https://ns.adobe.com/{TENANT_ID}/schemas/b1e6dd903c29dc7aea408ecd1ed040f0c161df7961fc50b2
-      - https://ns.adobe.com/{TENANT_ID}/schemas/d29a200b5deb6cfb55d3b865ef627f33
-      - https://ns.adobe.com/xdm/context/profile-person-details
-      - https://ns.adobe.com/xdm/context/profile-privacy
-      - https://ns.adobe.com/{TENANT_ID}/mixins/44850059caa530684c4507d0e01647e9
-      - https://ns.adobe.com/{TENANT_ID}/schemas/e348088f36cb2dc90d14737de6832aa35c7a7f1a116e1dbe
-      - https://ns.adobe.com/xdm/mixins/profile/profile-loyalty-details
-      - https://ns.adobe.com/xdm/context/profile-personal-details
-      - https://ns.adobe.com/xdm/data/record
-      - https://ns.adobe.com/experience/profile-edgeregion
-      - https://ns.adobe.com/xdm/context/identitymap
-      - https://ns.adobe.com/{TENANT_ID}/schemas/ebbbb87cb534798841d760ea2c5d861d
-      - https://ns.adobe.com/{TENANT_ID}/schemas/3494225dfbfb0d9ac346b00a1142c3a1c0751aff9dbbf5ef
-      - https://ns.adobe.com/{TENANT_ID}/schemas/6fd18629565e429e5379c77c2755618b
-      - https://ns.adobe.com/xdm/context/profile-test-profile
-      - https://ns.adobe.com/{TENANT_ID}/schemas/4fcf5778706905d53c138b1ed4d94c6c
-      - https://ns.adobe.com/{TENANT_ID}/mixins/03a07059cad2a4d772385bcf8105750f
-      - https://ns.adobe.com/{TENANT_ID}/mixins/6287e6dfaf504f1eb47842492431255d
-      - https://ns.adobe.com/{TENANT_ID}/schemas/ac95d88f11b47688ef2f24f55fe5f3a9a607bb2c4325e68d
-      - https://ns.adobe.com/{TENANT_ID}/schemas/70e3226d662a19800837b7dd7cfc3ef6
-      - https://ns.adobe.com/{TENANT_ID}/schemas/5df4f4cc39462136cbbead3481f878a878420025282a53b8
-      - https://ns.adobe.com/{TENANT_ID}/schemas/3a1859ec31ba93153050f92d981aec5d97b350d22cf960d5
-      - https://ns.adobe.com/{TENANT_ID}/mixins/1e9576c98a5d2a67ac90da1a271f5eb2
-      - https://ns.adobe.com/{TENANT_ID}/schemas/3d569c62921ac9371ad148afbaec3891547aca2a49575cef
-      meta:xdmType: object
-      meta:registryMetadata:
-        eTag: e4655a460374dec4dd7c32d3075a4ffc8249146b4d9c6ae09682da51266a78da
-        meta:globalLibVersion: 1.28.1
-      meta:class: https://ns.adobe.com/xdm/context/profile
-      meta:containerId: tenant
-      meta:sandboxId: 28e74200-e3de-11e9-8f5d-7f27416c5f0d
-      meta:sandboxType: production
-
-  unionBasic:
-    allOf:
-      - $ref: '#/definitions/lookupResourceCore'
-      - properties:
-          'allOf':
+      - $ref: '#/components/schemas/lookupResourceCore'
+      - type: object
+        properties:
+          allOf:
             type: array
-            description: Lists the class and/or field groups that comprise the union schema.
+            description: Lists the class and/or field groups that comprise the union
+              schema.
             items:
+              type: object
               properties:
                 $ref:
                   type: string
-                  description: The `$id` of the class or field group whose fields are included in the union.
+                  description: The `$id` of the class or field group whose fields
+                    are included in the union.
           imsOrg:
             type: string
             description: The ID for the IMS Organization that owns the union schema.
           meta:extends:
             type: array
-            description: A list of `$id` strings for the schemas, field groups, and other resources that participate in the union.
+            description: "A list of `$id` strings for the schemas, field groups, and\
+              \ other resources that participate in the union."
             items:
               type: string
           meta:xdmType:
             type: string
-            description: The JSON Schema data type for the resource, typically `object`.
+            description: "The JSON Schema data type for the resource, typically `object`."
           meta:registryMetadata:
             type: object
-            description: Contains various metadata about the union schema.
             properties:
               etag:
                 type: string
@@ -2800,528 +4371,184 @@ definitions:
               meta:globalLibVersion:
                 type: string
                 description: The current global library version of the union schema.
+            description: Contains various metadata about the union schema.
           meta:class:
             type: string
             description: The `$id` of the class this union schema is based on.
           meta:containerId:
             type: string
             description: The container that the union is located in.
-    example:
-      "$id": https://ns.adobe.com/xdm/context/profile__union
-      meta:altId: _xdm.context.profile__union
-      meta:resourceType: unions
-      version: '1.0'
-      title: XDM Individual Profile
-      type: object
-      description: An XDM Individual Profile forms a singular representation of the attributes
-        and interests of both identified and partially-identified individuals. Less-identified
-        profiles may contain only anonymous behavioral signals, such as browser cookies,
-        while highly-identified profiles may contain detailed personal information such
-        as name, date of birth, location, and email address. As a profile grows, it becomes
-        a robust repository of personal information, identification information, contact
-        details, and communication preferences for an individual.
+    patchClass:
       allOf:
-        - "$ref": https://ns.adobe.com/techmarketingdemos/mixins/50ac8a9b7bcc18ef87e58d5bda3150f9
-        - "$ref": https://ns.adobe.com/techmarketingdemos/mixins/26625cc93fbf2312f8751d4a7240bb57
-        - "$ref": https://ns.adobe.com/techmarketingdemos/mixins/f267eca0b424da08ae39cdf669310654
-        - "$ref": https://ns.adobe.com/xdm/mixins/profile-consents
-        - "$ref": https://ns.adobe.com/techmarketingdemos/mixins/cceb0516bbef095b0c52c939e108e06c
-        - "$ref": https://ns.adobe.com/xdm/common/external-source-system-audit-details
-        - "$ref": https://ns.adobe.com/techmarketingdemos/mixins/7259a2cf4a35350010a9869e633e548ee261bb9161e43db2
-        - "$ref": https://ns.adobe.com/techmarketingdemos/mixins/43b552826481ed09e5b51c622bcd1f56d41f9f89f099bbb8
-        - "$ref": https://ns.adobe.com/xdm/context/profile-person-details
-        - "$ref": https://ns.adobe.com/xdm/context/profile-privacy
-        - "$ref": https://ns.adobe.com/xdm/context/profile-personal-details
-        - "$ref": https://ns.adobe.com/techmarketingdemos/mixins/86794f1df304cd33c2acf6fa214a4ff0
-        - "$ref": https://ns.adobe.com/experience/profile-edgeregion
-        - "$ref": https://ns.adobe.com/xdm/context/identitymap
-        - "$ref": https://ns.adobe.com/techmarketingdemos/mixins/d103d3a18576767ab070ac0c87e8366576269c7e0846fbbb
-        - "$ref": https://ns.adobe.com/experience/profile/profile-all
-        - "$ref": https://ns.adobe.com/xdm/context/profile-work-details
-        - "$ref": https://ns.adobe.com/xdm/context/profile-test-profile
-        - "$ref": https://ns.adobe.com/techmarketingdemos/mixins/3bf207b597df895b0cf224410d03c10f
-        - "$ref": https://ns.adobe.com/techmarketingdemos/mixins/f8619816e425a2b804fc32225dddbe51
-        - "$ref": https://ns.adobe.com/techmarketingdemos/mixins/fc99a187af7a14831e8efd57a4fe3ae345fd909214abf7d9
-        - "$ref": https://ns.adobe.com/techmarketingdemos/mixins/cfb414f970e50975469ffd7066c2d56099ddab875bb10fb1
-        - "$ref": https://ns.adobe.com/techmarketingdemos/mixins/2204efd97f4b45bc0a5deb59d46084d7
-        - "$ref": https://ns.adobe.com/xdm/context/profile
-        - "$ref": https://ns.adobe.com/xdm/context/profile-segmentation
-        - "$ref": https://ns.adobe.com/xdm/context/profile-preferences-details
-        - "$ref": https://ns.adobe.com/techmarketingdemos/mixins/9cc2d107ab9af10c2688083ae0fb3c2d
-        - "$ref": https://ns.adobe.com/techmarketingdemos/mixins/b3729e80580bce82f08be698deeae0a657893be573288b82
-      imsOrg: 7ABB3E6A5A7491460A495D61@AdobeOrg
-      meta:extends:
-        - https://ns.adobe.com/techmarketingdemos/mixins/26625cc93fbf2312f8751d4a7240bb57
-        - https://ns.adobe.com/techmarketingdemos/mixins/f267eca0b424da08ae39cdf669310654
-        - https://ns.adobe.com/xdm/common/extensible
-        - https://ns.adobe.com/techmarketingdemos/schemas/cdabd86a307eecdae9e01ad3638b24d5
-        - https://ns.adobe.com/techmarketingdemos/schemas/3797a5be100381c705b3d51c1712f86da4796ccc10833242
-        - https://ns.adobe.com/techmarketingdemos/schemas/19b938a17c9847719d5807a3bcd8837f0fcaafb32d37308a
-        - https://ns.adobe.com/xdm/mixins/profile-consents
-        - https://ns.adobe.com/xdm/common/external-source-system-audit-details
-        - https://ns.adobe.com/techmarketingdemos/schemas/60f8e4e482e80c4b9245e68fbcfcfd2d2baac5140b5de852
-        - https://ns.adobe.com/techmarketingdemos/schemas/ad73b6f080026ba659b4da4d0416fe69
-        - https://ns.adobe.com/techmarketingdemos/schemas/dc94ab81c30c1f97a8f4c38d5bd492cd
-        - https://ns.adobe.com/techmarketingdemos/mixins/86794f1df304cd33c2acf6fa214a4ff0
-        - https://ns.adobe.com/techmarketingdemos/schemas/5983109319062ca5effcd13857cbcc0d
-        - https://ns.adobe.com/experience/profile/profile-all
-        - https://ns.adobe.com/xdm/context/profile-work-details
-        - https://ns.adobe.com/techmarketingdemos/schemas/56ae613751991cb72707cea9168e1cb8e5635bb008c75c74
-        - https://ns.adobe.com/techmarketingdemos/schemas/43e451554794cf3b2ae685708d46f5d118e63d1d53154070
-        - https://ns.adobe.com/techmarketingdemos/mixins/3bf207b597df895b0cf224410d03c10f
-        - https://ns.adobe.com/techmarketingdemos/schemas/b52f98d5027c54e3df56f5c9fbd78d2b67917542ce74736e
-        - https://ns.adobe.com/techmarketingdemos/mixins/fc99a187af7a14831e8efd57a4fe3ae345fd909214abf7d9
-        - https://ns.adobe.com/techmarketingdemos/mixins/cfb414f970e50975469ffd7066c2d56099ddab875bb10fb1
-        - https://ns.adobe.com/techmarketingdemos/schemas/cf6802dd86d2b9386933beacda58196d098e833eca673004
-        - https://ns.adobe.com/techmarketingdemos/mixins/2204efd97f4b45bc0a5deb59d46084d7
-        - https://ns.adobe.com/xdm/context/profile
-        - https://ns.adobe.com/xdm/context/profile-segmentation
-        - https://ns.adobe.com/xdm/context/profile-preferences-details
-        - https://ns.adobe.com/techmarketingdemos/mixins/9cc2d107ab9af10c2688083ae0fb3c2d
-        - https://ns.adobe.com/techmarketingdemos/mixins/b3729e80580bce82f08be698deeae0a657893be573288b82
-        - https://ns.adobe.com/techmarketingdemos/schemas/8d3a0342fecad26daebcb50098d9ab04
-        - https://ns.adobe.com/techmarketingdemos/mixins/50ac8a9b7bcc18ef87e58d5bda3150f9
-        - https://ns.adobe.com/xdm/common/auditable
-        - https://ns.adobe.com/techmarketingdemos/mixins/cceb0516bbef095b0c52c939e108e06c
-        - https://ns.adobe.com/techmarketingdemos/mixins/7259a2cf4a35350010a9869e633e548ee261bb9161e43db2
-        - https://ns.adobe.com/techmarketingdemos/mixins/43b552826481ed09e5b51c622bcd1f56d41f9f89f099bbb8
-        - https://ns.adobe.com/xdm/context/profile-person-details
-        - https://ns.adobe.com/xdm/context/profile-privacy
-        - https://ns.adobe.com/xdm/context/profile-personal-details
-        - https://ns.adobe.com/xdm/data/record
-        - https://ns.adobe.com/experience/profile-edgeregion
-        - https://ns.adobe.com/xdm/context/identitymap
-        - https://ns.adobe.com/techmarketingdemos/mixins/d103d3a18576767ab070ac0c87e8366576269c7e0846fbbb
-        - https://ns.adobe.com/techmarketingdemos/schemas/f9170cdc7d567ed74b7496397eb68231
-        - https://ns.adobe.com/techmarketingdemos/schemas/1ea97dacccd0432ce5654bed2a9a8f50
-        - https://ns.adobe.com/techmarketingdemos/schemas/470abbed5b45342e8eea05c8e06a0ebea865acd41a96b449
-        - https://ns.adobe.com/techmarketingdemos/schemas/947e45a31c1069cda73dbcb20cd63d18
-        - https://ns.adobe.com/xdm/context/profile-test-profile
-        - https://ns.adobe.com/techmarketingdemos/mixins/f8619816e425a2b804fc32225dddbe51
-        - https://ns.adobe.com/techmarketingdemos/schemas/141b1401469729d30ac38118f15c3883
-        - https://ns.adobe.com/techmarketingdemos/schemas/40e562df11a3ffa102ee6f92a88cf0b0
-        - https://ns.adobe.com/techmarketingdemos/schemas/83e86b0229788486f65ae9395aeae24bf1961404356532eb
-        - https://ns.adobe.com/techmarketingdemos/schemas/5dd02ef879a85ad105c44a0e939ce09f
-        - https://ns.adobe.com/techmarketingdemos/schemas/5b8d40b434bec502955d3e0144c4ce14d096897c6b0ca11f
-      meta:xdmType: object
-      meta:registryMetadata:
-        eTag: c6948ab68937fd879b9ff6ec0f8f6f892e3932b257903e7b7213716b50ad8ca4
-        meta:globalLibVersion: 1.27.4
-      meta:class: https://ns.adobe.com/xdm/context/profile
-      meta:containerId: tenant
-
-  patchClass:
-    allOf:
-      - $ref: '#/definitions/patchSchema'
-    example:
-      - op: replace
-        path: description
-        value: A PATCH-updated description for the class.
-  patchSchema:
-    type: array
-    description: A list of JSON Patch operation objects. Each object contains information about the action to be performed and the attribute to perform it on.
-    items:
-      type: object
-      properties:
-        op:
-          type: string
-          example: add
-          description: The JSON Patch operation to be performed.
-        path:
-          type: string
-          example: '/meta:immutableTags-'
-          description: The path to the field that the operation should be performed on.
-        value:
-          type: string
-          example: union
-          description: If adding or updating an attribute, this property indicates the value that should be set for that property.
-      required:
+      - $ref: '#/components/schemas/patchSchema'
+    patchSchema:
+      type: array
+      description: A list of JSON Patch operation objects. Each object contains information
+        about the action to be performed and the attribute to perform it on.
+      items:
+        required:
         - op
         - path
-  patchSchemaResponse:
-    allOf:
-      - $ref: '#/definitions/singleSchemaResponse'
-      - properties:
+        type: object
+        properties:
+          op:
+            type: string
+            description: The JSON Patch operation to be performed.
+            example: add
+          path:
+            type: string
+            description: The path to the field that the operation should be performed
+              on.
+            example: /meta:immutableTags-
+          value:
+            type: string
+            description: "If adding or updating an attribute, this property indicates\
+              \ the value that should be set for that property."
+            example: union
+    patchSchemaResponse:
+      allOf:
+      - $ref: '#/components/schemas/singleSchemaResponse'
+      - type: object
+        properties:
           version:
+            type: object
             example: "1.1"
           meta:immutableTags:
             type: array
-            description: When present and containing a single string value of `union`, indicates that this schema is enabled for use in Real-time Customer Profile.
-            items:
-              type: string
+            description: "When present and containing a single string value of `union`,\
+              \ indicates that this schema is enabled for use in Real-time Customer\
+              \ Profile."
             example:
-              - union
-  replaceSchema:
-    allOf:
-      - $ref: '#/definitions/createSchema'
-    type: object
-    properties:
-      type:
-        type: string
-        example: object
-      title:
-        type: string
-        example: New Schema
-      description:
-        type: string
-        example: Description of the new schema.
-      allOf:
-        type: array
-        items:
-          type: object
-          properties:
-            "$ref":
-              type: string
-              example: 'https://ns.adobe.com/{TENANT_ID}/classes/994062a01edc258a12cc730b71831854'
-    required:
-      - type
-      - title
-      - description
-      - allOf
-  listClassesResponse:
-    allOf:
-      - $ref: '#/definitions/listResponse'
-      - properties:
-          results:
+            - union
             items:
-              $ref: '#/definitions/singleClassResponse'
-    example:
-      results:
-        - "$id": https://ns.adobe.com/experience/journeyOrchestration/stepEvents/journey
-          meta:altId: _experience.journeyOrchestration.stepEvents.journey
-          meta:resourceType: classes
-          version: 1.27.4
-          title: Journey Orchestration Class
-          type: object
-          description: A Record based Journey class for Journey orchestration contains common
-            journey fields
-          definitions:
-            journeyClass:
-              properties: {}
-          allOf:
-          - "$ref": https://ns.adobe.com/xdm/data/record
-            type: object
-            meta:xdmType: object
-          - "$ref": "#/definitions/journeyClass"
-            type: object
-            meta:xdmType: object
-          auditable: true
-          meta:extensible: true
-          meta:abstract: true
-          meta:extends:
-          - https://ns.adobe.com/xdm/data/record
-          meta:xdmType: object
-          meta:status: stable
-          "$schema": http://json-schema.org/draft-06/schema#
-          meta:registryMetadata:
-            repo:createdDate: 1635361814823
-            repo:lastModifiedDate: 1635361814823
-            eTag: 351d2457ea40413a486ed6f328eb7f9384e63ded16019c7223e2586badf5a60a
-            meta:globalLibVersion: 1.27.4
-        - "$id": https://ns.adobe.com/experience/journeyOrchestration/stepEvents/journeyStepEvent
-          meta:altId: _experience.journeyOrchestration.stepEvents.journeyStepEvent
-          meta:resourceType: classes
-          version: 1.27.4
-          title: Journey Step Event
-          type: object
-          description: A time-series based Journey Step Event Class.
-          definitions:
-            journeyStepEventClass:
-              properties:
-                _experience:
-                  properties:
-                    journeyOrchestration:
-                      properties:
-                        serviceType:
-                          title: Service Type
-                          type: string
-                          description: This fields identifies the type of event.
-                          meta:xdmType: string
-                          meta:xdmField: https://ns.adobe.com/experience/journeyOrchestration/serviceType
-                      type: object
-                      meta:xdmType: object
-                      meta:xedConverted: true
-                  type: object
-                  meta:xdmType: object
-                  meta:xedConverted: true
-          allOf:
-          - "$ref": https://ns.adobe.com/xdm/data/time-series
-            type: object
-            meta:xdmType: object
-          - "$ref": "#/definitions/journeyStepEventClass"
-            type: object
-            meta:xdmType: object
-          meta:extensible: true
-          meta:abstract: true
-          meta:extends:
-          - https://ns.adobe.com/xdm/data/time-series
-          meta:xdmType: object
-          meta:status: stable
-          "$schema": http://json-schema.org/draft-06/schema#
-          meta:registryMetadata:
-            repo:createdDate: 1635361814826
-            repo:lastModifiedDate: 1635361814826
-            eTag: f9b83a0cc1d6ccd240ee3aebaf332d98876a0d749746ef9bfc0af99c713d0b43
-            meta:globalLibVersion: 1.27.4
-      _page:
-        orderby: updated
-        next:
-        count: 2
-      _links:
-        next:
-  createClass:
-    type: object
-    properties:
-      type:
-        type: string
-        description: The JSON Schema data type for the payload. Must be set to `object`.
-        example: object
-      title:
-        type: string
-        description: A title for the class.
-        example: New Class
-      description:
-        type: string
-        description: A description for the class.
-        example: Description of the new class.
-      allOf:
-        type: array
-        description: Lists the behavior that the class inherits along with any additional class-level fields.
-        items:
-          type: object
-          properties:
-            "$ref":
               type: string
-              description: The `$id` of the referenced XDM resource.
-              example: https://ns.adobe.com/xdm/data/record
-    required:
-      - type
-      - title
-      - description
+    replaceSchema:
+      required:
       - allOf
-  updateClassResponse:
-    allOf:
-      - $ref: '#/definitions/lookupClassResponse'
-    example:
-      "$id": https://ns.adobe.com/{TENANT_ID}/classes/9731ca27f72801dc6e9d6a170df94745
-      meta:altId: _{TENANT_ID}.classes.9731ca27f72801dc6e9d6a170df94745
-      meta:resourceType: classes
-      version: '1.0'
-      title: New Class
-      type: object
-      description: 'Updated description of the new class.'
+      - description
+      - title
+      - type
+      properties:
+        type:
+          type: string
+          example: object
+        title:
+          type: string
+          example: New Schema
+        description:
+          type: string
+          example: Description of the new schema.
+        allOf:
+          type: array
+          items:
+            type: object
+            properties:
+              $ref:
+                type: string
+                example: "https://ns.adobe.com/{TENANT_ID}/classes/994062a01edc258a12cc730b71831854"
       allOf:
-      - "$ref": https://ns.adobe.com/xdm/data/time-series
-      imsOrg: '{IMS_ORG}'
-      meta:extensible: true
-      meta:abstract: true
-      meta:extends:
-      - https://ns.adobe.com/xdm/data/time-series
-      meta:xdmType: object
-      meta:registryMetadata:
-        repo:createdDate: 1569014354925
-        repo:lastModifiedDate: 1569014354925
-        xdm:createdClientId: '{CLIENT_ID}'
-        xdm:lastModifiedClientId: '{CLIENT_ID}'
-        xdm:createdUserId: '{USER_ID}'
-        xdm:lastModifiedUserId: '{USER_ID}'
-        eTag: 3afbb3e8e4ea2ce02a2ba2fa31727a59a7a6d7d1ec70b62ca711058c26829761
-        meta:globalLibVersion: 1.27.4
-      meta:containerId: tenant
-      meta:sandboxId: 28e74200-e3de-11e9-8f5d-7f27416c5f0d
-      meta:sandboxType: production
-      meta:tenantNamespace: '_{TENANT_ID}'
-  patchClassResponse:
-    allOf:
-      - $ref: '#/definitions/lookupClassResponse'
-    example:
-      "$id": https://ns.adobe.com/{TENANT_ID}/classes/9731ca27f72801dc6e9d6a170df94745
-      meta:altId: _{TENANT_ID}.classes.9731ca27f72801dc6e9d6a170df94745
-      meta:resourceType: classes
-      version: '1.0'
-      title: New Class
-      type: object
-      description: 'A PATCH-updated description of the new class.'
+      - $ref: '#/components/schemas/createSchema'
+    listClassesResponse:
       allOf:
-      - "$ref": https://ns.adobe.com/xdm/data/record
-      imsOrg: '{IMS_ORG}'
-      meta:extensible: true
-      meta:abstract: true
-      meta:extends:
-      - https://ns.adobe.com/xdm/data/record
-      meta:xdmType: object
-      meta:registryMetadata:
-        repo:createdDate: 1569014354925
-        repo:lastModifiedDate: 1569014354925
-        xdm:createdClientId: '{CLIENT_ID}'
-        xdm:lastModifiedClientId: '{CLIENT_ID}'
-        xdm:createdUserId: '{USER_ID}'
-        xdm:lastModifiedUserId: '{USER_ID}'
-        eTag: 3afbb3e8e4ea2ce02a2ba2fa31727a59a7a6d7d1ec70b62ca711058c26829761
-        meta:globalLibVersion: 1.27.4
-      meta:containerId: tenant
-      meta:sandboxId: 28e74200-e3de-11e9-8f5d-7f27416c5f0d
-      meta:sandboxType: production
-      meta:tenantNamespace: '_{TENANT_ID}'
-  createClassResponse:
-    allOf:
-      - $ref: '#/definitions/lookupClassResponse'
-    example:
-      "$id": https://ns.adobe.com/{TENANT_ID}/classes/9731ca27f72801dc6e9d6a170df94745
-      meta:altId: _{TENANT_ID}.classes.9731ca27f72801dc6e9d6a170df94745
-      meta:resourceType: classes
-      version: '1.0'
-      title: New Class
+      - $ref: '#/components/schemas/listResponse'
+      - type: object
+        properties:
+          results:
+            type: object
+    createClass:
+      required:
+      - allOf
+      - description
+      - title
+      - type
       type: object
-      description: 'Description of the new class.'
+      properties:
+        type:
+          type: string
+          description: The JSON Schema data type for the payload. Must be set to `object`.
+          example: object
+        title:
+          type: string
+          description: A title for the class.
+          example: New Class
+        description:
+          type: string
+          description: A description for the class.
+          example: Description of the new class.
+        allOf:
+          type: array
+          description: Lists the behavior that the class inherits along with any additional
+            class-level fields.
+          items:
+            type: object
+            properties:
+              $ref:
+                type: string
+                description: The `$id` of the referenced XDM resource.
+                example: https://ns.adobe.com/xdm/data/record
+    updateClassResponse:
       allOf:
-      - "$ref": https://ns.adobe.com/xdm/data/record
-      imsOrg: '{IMS_ORG}'
-      meta:extensible: true
-      meta:abstract: true
-      meta:extends:
-      - https://ns.adobe.com/xdm/data/record
-      meta:xdmType: object
-      meta:registryMetadata:
-        repo:createdDate: 1569014354925
-        repo:lastModifiedDate: 1569014354925
-        xdm:createdClientId: '{CLIENT_ID}'
-        xdm:lastModifiedClientId: '{CLIENT_ID}'
-        xdm:createdUserId: '{USER_ID}'
-        xdm:lastModifiedUserId: '{USER_ID}'
-        eTag: 3afbb3e8e4ea2ce02a2ba2fa31727a59a7a6d7d1ec70b62ca711058c26829761
-        meta:globalLibVersion: 1.27.4
-      meta:containerId: tenant
-      meta:sandboxId: 28e74200-e3de-11e9-8f5d-7f27416c5f0d
-      meta:sandboxType: production
-      meta:tenantNamespace: '_{TENANT_ID}'
-  lookupClassResponse:
-    allOf:
-      - $ref: '#/definitions/singleSchemaResponse'
-      - $ref: '#/definitions/resourceContainers'
-      - $ref: '#/definitions/metaTenantNamespace'
-    example:
-      "$id": https://ns.adobe.com/{TENANT_ID}/classes/9731ca27f72801dc6e9d6a170df94745
-      meta:altId: _{TENANT_ID}.classes.9731ca27f72801dc6e9d6a170df94745
-      meta:resourceType: classes
-      version: '1.0'
-      title: Luma Product Class
-      type: object
-      description: 'A custom product class for the Luma brand.'
+      - $ref: '#/components/schemas/lookupClassResponse'
+    patchClassResponse:
       allOf:
-      - "$ref": https://ns.adobe.com/xdm/data/record
-      imsOrg: '{IMS_ORG}'
-      meta:extensible: true
-      meta:abstract: true
-      meta:extends:
-      - https://ns.adobe.com/xdm/data/record
-      meta:xdmType: object
-      meta:registryMetadata:
-        repo:createdDate: 1569014354925
-        repo:lastModifiedDate: 1569014354925
-        xdm:createdClientId: '{CLIENT_ID}'
-        xdm:lastModifiedClientId: '{CLIENT_ID}'
-        xdm:createdUserId: '{USER_ID}'
-        xdm:lastModifiedUserId: '{USER_ID}'
-        eTag: 3afbb3e8e4ea2ce02a2ba2fa31727a59a7a6d7d1ec70b62ca711058c26829761
-        meta:globalLibVersion: 1.27.4
-      meta:containerId: tenant
-      meta:sandboxId: 28e74200-e3de-11e9-8f5d-7f27416c5f0d
-      meta:sandboxType: production
-      meta:tenantNamespace: '_{TENANT_ID}'
-  meta:datasetNamespace:
-    type: object
-    properties:
-      meta:datasetNamespace:
-        type: string
-        description: ""
-  replaceClass:
-    allOf:
-      - $ref: '#/definitions/createClass'
-      - properties:
+      - $ref: '#/components/schemas/lookupClassResponse'
+    createClassResponse:
+      allOf:
+      - $ref: '#/components/schemas/lookupClassResponse'
+    lookupClassResponse:
+      allOf:
+      - $ref: '#/components/schemas/singleSchemaResponse'
+      - $ref: '#/components/schemas/resourceContainers'
+      - $ref: '#/components/schemas/metaTenantNamespace'
+    replaceClass:
+      allOf:
+      - $ref: '#/components/schemas/createClass'
+      - type: object
+        properties:
           description:
+            type: object
             example: Updated description of the new class.
           allOf:
-            items:
-              properties:
-                "$ref":
-                  example: https://ns.adobe.com/xdm/data/time-series
-  createFieldGroup:
-    type: object
-    properties:
-      type:
-        type: string
-        description: The JSON Schema data type for the field group. Must be set to `object`.
-        example: object
-      title:
-        type: string
-        description: A title for the field group.
-        example: Property Details
-      description:
-        type: string
-        description: A description for the field group.
-        example: Detailed information related to the properties owned and operated by the company.
-      meta:intendedToExtend:
-        type: array
-        description: Contains the `$id` value(s) of the class(es) that this field group is compatible with.
-        items:
-          type: string
-          description: The `$id` value of the class that this field group is compatible with.
-          example: 'https://ns.adobe.com/{TENANT_ID}/classes/19e1d8b5098a7a76e2c10a81cbc99590'
-      definitions:
-        type: object
-        description: Describes the unique attributes provided by the field group that are not inherited from other XDM resources. Custom attributes must be nested under `properties._{TENANT_ID}` to avoid collisions with similar fields provided by classes and other field groups. For details on how to define different field types to include in your field group, see the [field constraints guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/schema/field-constraints.html?lang=en#define-fields).
-        example:
-          property:
-            properties:
-              _{TENANT_ID}:
-                type: object
-                properties:
-                  propertyName:
-                    type: string
-                    title: Property Name
-                    description: Name of the property
-                  propertyCity:
-                    title: Property City
-                    description: City where the property is located.
-                    type: string
-                  phoneNumber:
-                    title: Phone Number
-                    description: Primary phone number for the property.
-                    type: string
-                  propertyType:
-                    type: string
-                    title: Property Type
-                    description: Type and primary use of property.
-                    enum:
-                    - retail
-                    - yoga
-                    - fitness
-                    meta:enum:
-                      retail: Retail Store
-                      yoga: Yoga Studio
-                      fitness: Fitness Center
-                  propertyConstruction:
-                    "$ref": https://ns.adobe.com/{TENANT_ID}/datatypes/24c643f618647344606222c494bd0102
-      allOf:
-        type: array
-        description: A list of reference strings that determine the attributes that the field group provides. A string can refer to a custom field definition provided under the `definitions` object (e.g. `#/definitions/property`) or the `$id` of another field group or data type that this field group extends or employs.
-        items:
-          type: object
-          properties:
-            $ref:
-              type: string
-              description: A string reference to a custom field definition provided under the `definitions` object (e.g. `#/definitions/property`) or the `$id` of another field group or data type that this field group extends or employs.
-              example: '#/definitions/property'
-    required:
-      - type
-      - title
+            type: object
+    createFieldGroup:
+      required:
       - meta:intendedToExtend
-  patchFieldGroupResponse:
-    allOf:
-      - $ref: '#/definitions/updateFieldGroupResponse'
-      - properties:
-         definitions:
+      - title
+      - type
+      type: object
+      properties:
+        type:
+          type: string
+          description: The JSON Schema data type for the field group. Must be set
+            to `object`.
+          example: object
+        title:
+          type: string
+          description: A title for the field group.
+          example: Property Details
+        description:
+          type: string
+          description: A description for the field group.
+          example: Detailed information related to the properties owned and operated
+            by the company.
+        meta:intendedToExtend:
+          type: array
+          description: Contains the `$id` value(s) of the class(es) that this field
+            group is compatible with.
+          items:
+            type: string
+            description: The `$id` value of the class that this field group is compatible
+              with.
+            example: "https://ns.adobe.com/{TENANT_ID}/classes/19e1d8b5098a7a76e2c10a81cbc99590"
+        definitions:
+          type: object
+          properties: {}
+          description: "Describes the unique attributes provided by the field group\
+            \ that are not inherited from other XDM resources. Custom attributes must\
+            \ be nested under `properties._{TENANT_ID}` to avoid collisions with similar\
+            \ fields provided by classes and other field groups. For details on how\
+            \ to define different field types to include in your field group, see\
+            \ the [field constraints guide](https://experienceleague.adobe.com/docs/experience-platform/xdm/schema/field-constraints.html?lang=en#define-fields)."
           example:
             property:
               properties:
@@ -3335,10 +4562,6 @@ definitions:
                     propertyCity:
                       title: Property City
                       description: City where the property is located.
-                      type: string
-                    propertyCountry:
-                      title: Property Country
-                      description: Country where the property is located.
                       type: string
                     phoneNumber:
                       title: Phone Number
@@ -3357,1232 +4580,892 @@ definitions:
                         yoga: Yoga Studio
                         fitness: Fitness Center
                     propertyConstruction:
-                      "$ref": https://ns.adobe.com/{TENANT_ID}/datatypes/24c643f618647344606222c494bd0102
-
-  updateFieldGroupResponse:
-    allOf:
-      - $ref: '#/definitions/createFieldGroupResponse'
-      - properties:
+                      $ref: "https://ns.adobe.com/{TENANT_ID}/datatypes/24c643f618647344606222c494bd0102"
+        allOf:
+          type: array
+          description: A list of reference strings that determine the attributes that
+            the field group provides. A string can refer to a custom field definition
+            provided under the `definitions` object (e.g. `#/definitions/property`)
+            or the `$id` of another field group or data type that this field group
+            extends or employs.
+          items:
+            type: object
+            properties:
+              $ref:
+                type: string
+                description: A string reference to a custom field definition provided
+                  under the `definitions` object (e.g. `#/definitions/property`) or
+                  the `$id` of another field group or data type that this field group
+                  extends or employs.
+                example: '#/definitions/property'
+    patchFieldGroupResponse:
+      allOf:
+      - $ref: '#/components/schemas/updateFieldGroupResponse'
+      - type: object
+        properties:
+          definitions:
+            type: object
+            example: ""
+    updateFieldGroupResponse:
+      allOf:
+      - $ref: '#/components/schemas/createFieldGroupResponse'
+      - type: object
+        properties:
           version:
-            example: '1.3'
-  createFieldGroupResponse:          
-    allOf:
-      - $ref: '#/definitions/singleFieldGroupResponse'
-    example:
-      "$id": https://ns.adobe.com/{TENANT_ID}/mixins/8779fd45d6e4eb074300023a439862bbba359b60d451627a
-      meta:altId: _{TENANT_ID}.mixins.8779fd45d6e4eb074300023a439862bbba359b60d451627a
-      meta:resourceType: mixins
-      version: '1.2'
-      title: Property Details
-      type: object
-      description: Detailed information related to the properties owned and operated by
-        the company.
-      definitions:
-        property:
-          properties:
-            _{TENANT_ID}:
-              type: object
-              properties:
-                propertyName:
-                  type: string
-                  title: Property Name
-                  description: Name of the property
-                propertyCity:
-                  title: Property City
-                  description: City where the property is located.
-                  type: string
-                phoneNumber:
-                  title: Phone Number
-                  description: Primary phone number for the property.
-                  type: string
-                propertyType:
-                  type: string
-                  title: Property Type
-                  description: Type and primary use of property.
-                  enum:
-                  - retail
-                  - yoga
-                  - fitness
-                  meta:enum:
-                    retail: Retail Store
-                    yoga: Yoga Studio
-                    fitness: Fitness Center
-                propertyConstruction:
-                  "$ref": https://ns.adobe.com/{TENANT_ID}/datatypes/24c643f618647344606222c494bd0102
+            type: object
+            example: "1.3"
+    createFieldGroupResponse:
       allOf:
-      - "$ref": "#/definitions/customFields"
-        type: object
-        meta:xdmType: object
-      imsOrg: "{IMS_ORG}"
-      meta:extensible: true
-      meta:abstract: true
-      meta:intendedToExtend:
-      - https://ns.adobe.com/xdm/context/profile
-      meta:xdmType: object
-      meta:registryMetadata:
-        repo:createdDate: 1594941263588
-        repo:lastModifiedDate: 1594941538433
-        xdm:createdClientId: "{CLIENT_ID}"
-        xdm:lastModifiedClientId: "{CLIENT_ID}"
-        xdm:createdUserId: "{USER_ID}"
-        xdm:lastModifiedUserId: "{USER_ID}"
-        eTag: 5e8a5e508eb2ed344c08cb23ed27cfb60c841bec59a2f7513deda0f7af903021
-        meta:globalLibVersion: 1.15.4
-      meta:containerId: tenant
-      meta:tenantNamespace: _{TENANT_ID}
-
-  lookupFieldGroupResponse:
-    allOf:
-      - $ref: '#/definitions/singleFieldGroupResponse'
-    example:
-      $id: 'https://ns.adobe.com/xdm/context/profile-person-details'
-      'meta:altId': _xdm.context.profile-person-details
-      'meta:resourceType': mixins
-      version: 1.22.3
-      title: Demographic Details
-      type: object
-      description: 'Demographic information such as name, gender, and birth date of an individual.'
-      definitions:
-        profile-person-details:
-          properties:
-            person:
-              title: Person
-              $ref: 'https://ns.adobe.com/xdm/context/person'
-              description: 'An individual actor, contact, or owner.'
-              type: object
-              'meta:xdmType': object
-              'meta:xdmField': 'xdm:person'
+      - $ref: '#/components/schemas/singleFieldGroupResponse'
+    lookupFieldGroupResponse:
       allOf:
-        - $ref: 'https://ns.adobe.com/xdm/common/extensible%23/definitions/@context'
-          type: object
-          'meta:xdmType': object
-        - $ref: '#/definitions/profile-person-details'
-          type: object
-          'meta:xdmType': object
-      'meta:extensible': true
-      'meta:abstract': true
-      'meta:intendedToExtend':
-        - 'https://ns.adobe.com/xdm/context/profile'
-      'meta:xdmType': object
-      'meta:status': stable
-      $schema: 'http://json-schema.org/draft-06/schema#'
-      'meta:registryMetadata':
-        'repo:createdDate': 1620758109174
-        'repo:lastModifiedDate': 1620758109174
-        eTag: f5b20a7edefab1c4b1a86fbd4de91570b57d36b9f2c6deb3225a18d14fafce3b
-        'meta:globalLibVersion': 1.22.3
-        'meta:usageCount': 29
-      'meta:tags':
-        industry:
-          - all
-      'meta:createdDate': '2020-08-10'
-  patchFieldGroup:
-    allOf:
-      - $ref: '#/definitions/patchSchema'
-    example:
-      - op: add
-        path: /definitions/property/properties/_{TENANT_ID}/properties/propertyCity
-        value:
-          title: Property Country
-          description: The country where the property is located.
-          type: string
-  replaceFieldGroup:
-    allOf:
-      - $ref: '#/definitions/createFieldGroup'
-  listDataTypesResponse:
-    allOf:
-      - $ref: '#/definitions/listResponse'
-      - properties:
+      - $ref: '#/components/schemas/singleFieldGroupResponse'
+    patchFieldGroup:
+      allOf:
+      - $ref: '#/components/schemas/patchSchema'
+    replaceFieldGroup:
+      allOf:
+      - $ref: '#/components/schemas/createFieldGroup'
+    listDataTypesResponse:
+      allOf:
+      - $ref: '#/components/schemas/listResponse'
+      - type: object
+        properties:
           results:
-            items:
-              allOf:
-                - $ref: '#/definitions/singleDataTypeResponse'
-                - properties:
-                    meta:createdDate:
-                      type: object
-                      description: (For `global` data types only) A timestamp of when the global data type was released.
-    example:
-      results:
-      - "$id": https://ns.adobe.com/xdm/context/webinfo
-        meta:altId: _xdm.context.webinfo
-        meta:resourceType: datatypes
-        version: 1.27.4
-        title: Web information
-        type: object
-        description: ''
-        definitions:
-          webinfo:
-            properties:
-              webInteraction:
-                title: Web interaction
-                type: object
-                description: Details about the web link or URL that corresponds to where
-                  the interaction occurred.
-                properties:
-                  URL:
-                    title: URL
-                    type: string
-                    description: The actual link or URL used for this web interaction.
-                    meta:xdmType: string
-                    meta:xdmField: xdm:URL
-                  linkClicks:
-                    title: Link Clicks
-                    "$ref": https://ns.adobe.com/xdm/data/measure
-                    description: Click of a web link has occurred.
-                    type: object
-                    meta:xdmType: object
-                    meta:xdmField: xdm:linkClicks
-                  name:
-                    title: Name
-                    type: string
-                    description: The normative name used for this web link, used for classification
-                      purposes.
-                    meta:xdmType: string
-                    meta:xdmField: xdm:name
-                  region:
-                    title: Region
-                    type: string
-                    description: The region name represents the region or area of a document
-                      that the web link belongs to such as header or footer.
-                    meta:xdmType: string
-                    meta:xdmField: xdm:region
-                  type:
-                    title: Type
-                    type: string
-                    description: The link type.
-                    enum:
-                    - download
-                    - exit
-                    - other
-                    meta:enum:
-                      download: Download
-                      exit: Exit
-                      other: Other
-                    meta:xdmType: string
-                    meta:xdmField: xdm:type
-                meta:xdmType: object
-                meta:xdmField: xdm:webInteraction
-              webPageDetails:
-                title: Web page details
-                type: object
-                description: Details about the web page where the web interaction occurred.
-                properties:
-                  URL:
-                    title: URL
-                    type: string
-                    description: The normative or usual URL of the web page.  This may or
-                      may not be the actual URL used to reach the page, which would be recorded
-                      using `Web Link`.
-                    meta:xdmType: string
-                    meta:xdmField: xdm:URL
-                  isErrorPage:
-                    title: Is error page
-                    type: boolean
-                    description: Flag that indicate if the page is error page or not.  Error
-                      here is defined by the application, and may nor may not correspond
-                      to a page served with an HTTP error code.  This flag is used to broadly
-                      categorize web interactions.
-                    meta:xdmType: boolean
-                    meta:xdmField: xdm:isErrorPage
-                  isHomePage:
-                    title: Is home page
-                    type: boolean
-                    description: Flag that indicate if the page is the site home page or
-                      not.  The definition of home page is determined by the application,
-                      but is commonly used to designate a top level landing page or common
-                      site entry point.  This flag is used to broadly categorize web interactions.
-                    meta:xdmType: boolean
-                    meta:xdmField: xdm:isHomePage
-                  name:
-                    title: Name
-                    type: string
-                    description: The normative name of the web page. This name is not necessarily
-                      the page title or directly associate with page content, but is used
-                      to organize a site's pages for classification purposes.
-                    meta:xdmType: string
-                    meta:xdmField: xdm:name
-                  pageViews:
-                    title: Page Views
-                    "$ref": https://ns.adobe.com/xdm/data/measure
-                    description: View(s) of a webpage has occurred.
-                    type: object
-                    meta:xdmType: object
-                    meta:xdmField: xdm:pageViews
-                  server:
-                    title: Server
-                    type: string
-                    description: The normative or usual server that hosts the web page.  This
-                      may or may not be the host or server that actually served the page
-                      interaction, but is used for classification purposes.
-                    meta:xdmType: string
-                    meta:xdmField: xdm:server
-                  siteSection:
-                    title: Site section
-                    type: string
-                    description: The normative name of the site section where this web page
-                      resides, which may be used to classify or categorize the interaction.
-                    meta:xdmType: string
-                    meta:xdmField: xdm:siteSection
-                  viewName:
-                    title: View Name
-                    type: string
-                    description: The name of the view, within a page. This is commonly used
-                      with Single Page Applications or pages that have tabs or controls
-                      that change a majority of the page layout.
-                    meta:xdmType: string
-                    meta:xdmField: xdm:viewName
-                meta:xdmType: object
-                meta:xdmField: xdm:webPageDetails
-              webReferrer:
-                title: Web referrer
-                type: object
-                description: The referrer of a web interaction, which is the URL a visitor
-                  came from immediately before the current web interaction was recorded.
-                properties:
-                  URL:
-                    title: URL
-                    type: string
-                    description: The referrer URL.
-                    meta:xdmType: string
-                    meta:xdmField: xdm:URL
-                  type:
-                    title: Type
-                    type: string
-                    description: The referrer type.
-                    enum:
-                    - internal
-                    - external
-                    - search_engine
-                    - typed_bookmarked
-                    - email
-                    - social
-                    - unknown
-                    - usenet
-                    meta:enum:
-                      internal: Internal
-                      external: External
-                      search_engine: Search engine
-                      typed_bookmarked: Typed or bookmarked
-                      email: Email
-                      social: Social network
-                      unknown: Unknown
-                      news: Usenet newsgroup
-                    meta:xdmType: string
-                    meta:xdmField: xdm:type
-                meta:xdmType: object
-                meta:xdmField: xdm:webReferrer
-        allOf:
-        - "$ref": https://ns.adobe.com/xdm/common/extensible#/definitions/@context
-          type: object
-          meta:xdmType: object
-        - "$ref": "#/definitions/webinfo"
-          type: object
-          meta:xdmType: object
-        meta:extensible: true
-        meta:xdmType: object
-        meta:status: stable
-        "$schema": http://json-schema.org/draft-06/schema#
-        meta:registryMetadata:
-          repo:createdDate: 1635361816390
-          repo:lastModifiedDate: 1635361816390
-          eTag: 9acb5ce67a37306d5b50f4d7d714ddac2bb30b4dcf8ccbef7affbb887b9f2677
-          meta:globalLibVersion: 1.27.4
-          meta:usageCount: 11
-        meta:createdDate: '2021-02-19'
-      - "$id": https://ns.adobe.com/xdm/content/productlistitem
-        meta:altId: _xdm.content.productlistitem
-        meta:resourceType: datatypes
-        version: 1.27.4
-        title: Product list item
-        type: object
-        description: The product list item represents a product selected by a customer with
-          specific options, pricing, usage context for a specific point of time and may
-          differ from the product record. For example the product record contains details
-          from the product information system that are consistent for all customers, where
-          the product list item has the actual price offered to the customer at that time
-          which may vary due to sales campaigns or seasonal pricing.
-        definitions:
-          productlistitem:
-            properties:
-              _id:
-                title: Line item ID.
-                type: string
-                format: uri-reference
-                description: The line item identifier for this product entry. The product
-                  itself is identified through `xdm:product`.
-                meta:xdmType: string
-                meta:xdmField: "@id"
-              SKU:
-                title: SKU
-                type: string
-                description: Stock keeping unit (SKU), the unique identifier for a product
-                  defined by the vendor.
-                meta:xdmType: string
-                meta:xdmField: xdm:SKU
-              currencyCode:
-                title: Currency code
-                type: string
-                examples:
-                - USD
-                - EUR
-                pattern: "^[A-Z]{3}$"
-                description: The ISO 4217 alphabetic currency code used for pricing the
-                  product.
-                meta:xdmType: string
-                meta:xdmField: xdm:currencyCode
-              name:
-                title: Name
-                type: string
-                description: The display name for the product as presented to the user for
-                  this product view.
-                meta:xdmType: string
-                meta:xdmField: xdm:name
-              priceTotal:
-                title: Price total
-                type: number
-                description: The total price for the product line item.
-                meta:xdmType: number
-                meta:xdmField: xdm:priceTotal
-              product:
-                title: Product
-                type: string
-                format: uri
-                description: The XDM identifier of the product itself.
-                meta:xdmType: string
-                meta:xdmField: xdm:product
-              productAddMethod:
-                title: Product add method
-                type: string
-                description: The method that was used to add a product item to the list
-                  by the visitor. Set with product list add metrics.
-                meta:xdmType: string
-                meta:xdmField: xdm:productAddMethod
-              quantity:
-                title: Quantity
-                type: integer
-                description: The number of units the customer has indicated they require
-                  of the product.
-                meta:xdmType: int
-                meta:xdmField: xdm:quantity
-            required:
-            - SKU
-        allOf:
-        - "$ref": "#/definitions/productlistitem"
-          type: object
-          meta:xdmType: object
-        - "$ref": https://ns.adobe.com/xdm/mixins/product-measurement#/definitions/uomcode
-          type: object
-          meta:xdmType: object
-        meta:xdmType: object
-        meta:status: stable
-        "$schema": http://json-schema.org/draft-06/schema#
-        meta:registryMetadata:
-          repo:createdDate: 1635361816394
-          repo:lastModifiedDate: 1635361816394
-          eTag: ba11c63e004dd1db02b7475cf2908b2611890f2e7bd139e31ff064bb424c24c7
-          meta:globalLibVersion: 1.27.4
-          meta:usageCount: 33
-        meta:createdDate: '2021-02-19'
-      _page:
-        orderby: updated
-        next:
-        count: 2
-      _links:
-        next:
-
-  createDataType:
-    type: object
-    properties:
-      type:
-        type: string
-        description: The JSON Schema data type for the resource. Must be set to `object` or `array`.
-        example: object
-      title:
-        type: string
-        description: A title for the data type.
-        example: Property Construction
-      description:
-        type: string
-        description: A description for the data type.
-        example: Information related to the property construction
-      properties:
-        type: object
-        description: If `type` is set to `object`, this field describes the attributes that the object will provide. Not supported for `array` data types. See the guide on [defining XDM field types in the API](https://experienceleague.adobe.com/docs/experience-platform/xdm/tutorials/custom-fields-api.html) for more information on how to format XDM fields.
-      items:
-        type: object
-        description: If `type` is set to `array`, this field describes the type and structure of each array list item. Not supported for `object` data types. See the guide on [defining XDM field types in the API](https://experienceleague.adobe.com/docs/experience-platform/xdm/tutorials/custom-fields-api.html) for more information on how to format XDM fields.
-    required:
-      - type
+            type: object
+    createDataType:
+      required:
       - title
-    example:
-      title: Property Construction
-      description: Information related to the property construction
+      - type
       type: object
       properties:
-        yearBuilt:
-          type: integer
-          title: Year Built
-          description: The year the property was constructed.
-        propertyType:
+        type:
           type: string
-          title: Property Type
-          description: Type of building or structure in which the property exists.
-          enum:
-          - freeStanding
-          - mall
-          - shoppingCenter
-          meta:enum:
-            freeStanding: Free Standing Building
-            mall: Mall Space
-            shoppingCenter: Shopping Center
-
-  patchDataTypeResponse:
-    allOf:
-      - $ref: '#/definitions/createDataTypeResponse'
-      - properties:
+          description: The JSON Schema data type for the resource. Must be set to
+            `object` or `array`.
+          example: object
+        title:
+          type: string
+          description: A title for the data type.
+          example: Property Construction
+        description:
+          type: string
+          description: A description for the data type.
+          example: Information related to the property construction
+        properties:
+          type: object
+          properties: {}
+          description: "If `type` is set to `object`, this field describes the attributes\
+            \ that the object will provide. Not supported for `array` data types.\
+            \ See the guide on [defining XDM field types in the API](https://experienceleague.adobe.com/docs/experience-platform/xdm/tutorials/custom-fields-api.html)\
+            \ for more information on how to format XDM fields."
+        items:
+          type: object
+          properties: {}
+          description: "If `type` is set to `array`, this field describes the type\
+            \ and structure of each array list item. Not supported for `object` data\
+            \ types. See the guide on [defining XDM field types in the API](https://experienceleague.adobe.com/docs/experience-platform/xdm/tutorials/custom-fields-api.html)\
+            \ for more information on how to format XDM fields."
+      example:
+        title: Property Construction
+        description: Information related to the property construction
+        type: object
+        properties:
+          yearBuilt:
+            type: integer
+            title: Year Built
+            description: The year the property was constructed.
+          propertyType:
+            type: string
+            title: Property Type
+            description: Type of building or structure in which the property exists.
+            enum:
+            - freeStanding
+            - mall
+            - shoppingCenter
+            meta:enum:
+              freeStanding: Free Standing Building
+              mall: Mall Space
+              shoppingCenter: Shopping Center
+    patchDataTypeResponse:
+      allOf:
+      - $ref: '#/components/schemas/createDataTypeResponse'
+      - type: object
+        properties:
           version:
-            example: '1.1'
+            type: object
+            example: "1.1"
           properties:
-            example:
-              field1:
-                title: Field 1
-                description: Description of Field 1.
-                type: string
-              field2:
-                title: Field 2
-                description: Description of Field 2.
-                type: integer
-              field3:
-                title: Field 3
-                description: Description of Field 3.
-                type: string
-                format: date
-
-  putDataTypeResponse:
-    allOf:
-      - $ref: '#/definitions/createDataTypeResponse'
-      - properties:
+            type: object
+            example: ""
+    putDataTypeResponse:
+      allOf:
+      - $ref: '#/components/schemas/createDataTypeResponse'
+      - type: object
+        properties:
           description:
+            type: object
             example: Updated description of the data type.
           version:
-            example: '1.1'
-      
-  createDataTypeResponse:
-    allOf:
-      - $ref: '#/definitions/singleDataTypeResponse'
-      - $ref: '#/definitions/resourceContainers'
-      - $ref: '#/definitions/metaTenantNamespace'
-    example:
-      "$id": https://ns.adobe.com/{TENANT_ID}/datatypes/669ffcc61cf5e94e8640dbe6a15f0f24eb3cd1ddbbfb6b36
-      meta:altId: _{TENANT_ID}.datatypes.669ffcc61cf5e94e8640dbe6a15f0f24eb3cd1ddbbfb6b36
-      meta:resourceType: datatypes
-      version: '1.0'
-      title: Property Construction
-      type: object
-      description: Information related to the property construction
-      properties:
-        yearBuilt:
-          type: integer
-          title: Year Built
-          description: The year the property was constructed.
-          meta:xdmType: int
-        propertyType:
-          type: string
-          title: Property Type
-          description: Type of building or structure in which the property exists.
-          enum:
-          - freeStanding
-          - mall
-          - shoppingCenter
-          meta:enum:
-            freeStanding: Free Standing Building
-            mall: Mall Space
-            shoppingCenter: Shopping Center
-          meta:xdmType: string
-      refs: []
-      imsOrg: "{ORG_ID}"
-      meta:extensible: true
-      meta:abstract: true
-      meta:xdmType: object
-      meta:registryMetadata:
-        repo:createdDate: 1670885230789
-        repo:lastModifiedDate: 1670885230789
-        xdm:createdClientId: "{CLIENT_ID}"
-        xdm:lastModifiedClientId: "{CLIENT_ID}"
-        xdm:createdUserId: "{USER_ID}"
-        xdm:lastModifiedUserId: "{USER_ID}"
-        eTag: d3cc803a1f8daa06b7c150d882bd337d88f4d5d5f08d36cfc4c2849dc0255f7e
-        meta:globalLibVersion: 1.38.3.1
-      meta:containerId: tenant
-      meta:sandboxId: 1bd86660-c5da-11e9-93d4-6d5fc3a66a8e
-      meta:sandboxType: production
-      meta:tenantNamespace: _{TENANT_ID}
-
-
-  lookupDataTypeResponse:
-    allOf:
-      - $ref: '#/definitions/singleDataTypeResponse'
-      - properties:
+            type: object
+            example: "1.1"
+    createDataTypeResponse:
+      allOf:
+      - $ref: '#/components/schemas/singleDataTypeResponse'
+      - $ref: '#/components/schemas/resourceContainers'
+      - $ref: '#/components/schemas/metaTenantNamespace'
+    lookupDataTypeResponse:
+      allOf:
+      - $ref: '#/components/schemas/singleDataTypeResponse'
+      - type: object
+        properties:
           meta:createdDate:
             type: object
-            description: (For `global` data types only) A timestamp of when the global data type was released.
-    example:
-      "$id": https://ns.adobe.com/xdm/content/productlistitem
-      meta:altId: _xdm.content.productlistitem
-      meta:resourceType: datatypes
-      version: 1.27.4
-      title: Product list item
-      type: object
-      description: The product list item represents a product selected by a customer with
-        specific options, pricing, usage context for a specific point of time and may differ
-        from the product record. For example the product record contains details from the
-        product information system that are consistent for all customers, where the product
-        list item has the actual price offered to the customer at that time which may vary
-        due to sales campaigns or seasonal pricing.
-      definitions:
-        productlistitem:
-          properties:
-            _id:
-              title: Line item ID.
+            properties: {}
+            description: (For `global` data types only) A timestamp of when the global
+              data type was released.
+    patchDataType:
+      type: array
+      items:
+        type: object
+        properties:
+          op:
+            type: string
+            description: Type of JSON Patch operation being performed.
+            example: add
+          path:
+            type: string
+            description: Location where the operation is being performed.
+            example: /properties/field3
+          value:
+            type: object
+            properties: {}
+            description: "Required elements vary depending on type of 'value' (e.g.\
+              \ string, integer, object, etc.)"
+            example:
+              title: Field 3
               type: string
-              format: uri-reference
-              description: The line item identifier for this product entry. The product
-                itself is identified through `xdm:product`.
-              meta:xdmType: string
-              meta:xdmField: "@id"
-            SKU:
-              title: SKU
-              type: string
-              description: Stock keeping unit (SKU), the unique identifier for a product
-                defined by the vendor.
-              meta:xdmType: string
-              meta:xdmField: xdm:SKU
-            currencyCode:
-              title: Currency code
-              type: string
-              examples:
-              - USD
-              - EUR
-              pattern: "^[A-Z]{3}$"
-              description: The ISO 4217 alphabetic currency code used for pricing the product.
-              meta:xdmType: string
-              meta:xdmField: xdm:currencyCode
-            name:
-              title: Name
-              type: string
-              description: The display name for the product as presented to the user for
-                this product view.
-              meta:xdmType: string
-              meta:xdmField: xdm:name
-            priceTotal:
-              title: Price total
-              type: number
-              description: The total price for the product line item.
-              meta:xdmType: number
-              meta:xdmField: xdm:priceTotal
-            product:
-              title: Product
-              type: string
-              format: uri
-              description: The XDM identifier of the product itself.
-              meta:xdmType: string
-              meta:xdmField: xdm:product
-            productAddMethod:
-              title: Product add method
-              type: string
-              description: The method that was used to add a product item to the list by
-                the visitor. Set with product list add metrics.
-              meta:xdmType: string
-              meta:xdmField: xdm:productAddMethod
-            quantity:
-              title: Quantity
-              type: integer
-              description: The number of units the customer has indicated they require of
-                the product.
-              meta:xdmType: int
-              meta:xdmField: xdm:quantity
-          required:
-          - SKU
+              format: date
+              description: Description of Field 3.
+    replaceDataType:
       allOf:
-      - "$ref": "#/definitions/productlistitem"
-        type: object
-        meta:xdmType: object
-      - "$ref": https://ns.adobe.com/xdm/mixins/product-measurement#/definitions/uomcode
-        type: object
-        meta:xdmType: object
-      meta:xdmType: object
-      meta:status: stable
-      "$schema": http://json-schema.org/draft-06/schema#
-      meta:registryMetadata:
-        repo:createdDate: 1635361816394
-        repo:lastModifiedDate: 1635361816394
-        eTag: ba11c63e004dd1db02b7475cf2908b2611890f2e7bd139e31ff064bb424c24c7
-        meta:globalLibVersion: 1.27.4
-        meta:usageCount: 33
-      meta:createdDate: '2021-02-19'
-  patchDataType:
-    type: array
-    items:
+      - $ref: '#/components/schemas/createDataType'
+      - type: object
+        properties:
+          description:
+            type: object
+            example: Updated description for the data type.
+    listDescriptorsResponse:
       type: object
       properties:
-        op:
-          description: Type of JSON Patch operation being performed.
+        xdm:alternateDisplayInfo:
+          type: array
+          description: Lists the friendly name descriptors owned by your organization.
+          items:
+            $ref: '#/components/schemas/friendlyNameDescriptorResponse'
+        xdm:descriptorIdentity:
+          type: array
+          description: Lists the identity descriptors owned by your organization.
+          items:
+            $ref: '#/components/schemas/identityDescriptorResponse'
+        xdm:descriptorReferenceIdentity:
+          type: array
+          description: Lists the reference identity descriptors owned by your organization.
+          items:
+            $ref: '#/components/schemas/referenceDescriptorResponse'
+        xdm:descriptorOneToOne:
+          type: array
+          description: Lists the relationship descriptors owned by your organization.
+          items:
+            $ref: '#/components/schemas/relationshipDescriptorResponse'
+    lookupDescriptorResponse:
+      required:
+      - '@type'
+      - xdm:sourceSchema
+      - xdm:sourceVersion
+      type: object
+      properties:
+        '@type':
           type: string
-          example: add
-        path:
-          description: Location where the operation is being performed.
+          example: xdm:descriptorIdentity
+          enum:
+          - xdm:descriptorOneToOne
+          - xdm:descriptorOneToMany
+          - xdm:descriptorManyToMany
+          - xdm:descriptorIdentity
+          - xdm:descriptorPrimaryKey
+          - xdm:alternateDisplayInfo
+        xdm:sourceSchema:
           type: string
-          example: '/properties/field3'
-        value:
-          description: Required elements vary depending on type of 'value' (e.g. string, integer, object, etc.)
-          type: object
-          example: {"title": "Field 3", "type": "string", "format": "date", "description": "Description of Field 3."}
-  replaceDataType:
-    allOf:
-      - $ref: '#/definitions/createDataType'
-      - properties:
-          description:
-            example: Updated description for the data type.
-  listDescriptorsResponse:
-    type: object
-    properties:
-      xdm:alternateDisplayInfo:
-        type: array
-        description: Lists the friendly name descriptors owned by your organization.
-        items:
-          $ref: '#/definitions/friendlyNameDescriptorResponse'
-      xdm:descriptorIdentity:
-        type: array
-        description: Lists the identity descriptors owned by your organization.
-        items:
-          $ref: '#/definitions/identityDescriptorResponse'
-      xdm:descriptorReferenceIdentity:
-        type: array
-        description: Lists the reference identity descriptors owned by your organization.
-        items:
-          $ref: '#/definitions/referenceDescriptorResponse'
-      xdm:descriptorOneToOne:
-        type: array
-        description: Lists the relationship descriptors owned by your organization.
-        items:
-          $ref: '#/definitions/relationshipDescriptorResponse'
-  lookupDescriptorResponse:
-    type: object
-    properties:
-      '@type':
-        type: string
-        enum:
-        - xdm:descriptorOneToOne
-        - xdm:descriptorOneToMany
-        - xdm:descriptorManyToMany
-        - xdm:descriptorIdentity
-        - xdm:descriptorPrimaryKey
-        - xdm:alternateDisplayInfo
-        example: xdm:descriptorIdentity
-      'xdm:sourceSchema':
-        type: string
-        example: 'https://ns.adobe.com/{TENANT_ID}/schemas/fbc52b243d04b5d4f41eaa72a8ba58be'
-      'xdm:sourceVersion':
-        type: integer
-        example: 1
-      'xdm:sourceProperty':
-        type: string
-        example: '/mobilePhone/number'
-      'xdm:namespace':
-        type: string
-        example: Phone
-      'xdm:property':
-        type: string
-        enum: 
-        - xdm:id
-        - xdm:code
-        example: 'xdm:code'
-      'xdm:isPrimary':
-        type: boolean
-        example: false
-      'createdUser':
-        type: string
-      'imsOrg':
-        type: string
-      'createClient':
-        type: string
-      'updatedUser':
-        type: string
-      created:
-        type: integer
-        example: 1548900090542
-      update:
-        type: integer
-        example: 1548900090542
-      meta:containerId:
-        type: string
-        example: tenant
-      '@id':
-        type: string
-        example: '3c53ee74276b8342af3cc94129b5226272fd419c'
-    required:
-    - '@type'
-    - 'xdm:sourceSchema'
-    - 'xdm:sourceVersion'
-  createDescriptor:
-    type: object
-    properties:
-      '@type':
-        type: string
-        description: The descriptor type.
-        enum:
+          example: "https://ns.adobe.com/{TENANT_ID}/schemas/fbc52b243d04b5d4f41eaa72a8ba58be"
+        xdm:sourceVersion:
+          type: integer
+          example: 1
+        xdm:sourceProperty:
+          type: string
+          example: /mobilePhone/number
+        xdm:namespace:
+          type: string
+          example: Phone
+        xdm:property:
+          type: string
+          example: xdm:code
+          enum:
+          - xdm:id
+          - xdm:code
+        xdm:isPrimary:
+          type: boolean
+          example: false
+        createdUser:
+          type: string
+        imsOrg:
+          type: string
+        createClient:
+          type: string
+        updatedUser:
+          type: string
+        created:
+          type: integer
+          example: 1548900090542
+        update:
+          type: integer
+          example: 1548900090542
+        meta:containerId:
+          type: string
+          example: tenant
+        '@id':
+          type: string
+          example: 3c53ee74276b8342af3cc94129b5226272fd419c
+    createDescriptor:
+      type: object
+      properties:
+        '@type':
+          type: string
+          description: The descriptor type.
+          enum:
           - xdm:alternateDisplayInfo
           - xdm:descriptorIdentity
           - xdm:descriptorReferenceIdentity
           - xdm:descriptorOneToOne
-      xdm:sourceSchema:
-        type: string
-        description: The URI `$id` of the schema that this descriptor applies to.
-      xdm:sourceVersion:
-        type: string
-        description: The latest major version of the `sourceSchema`.
-      xdm:sourceProperty:
-        type: string
-        description: The path to the field within the `sourceSchema` that this descriptor applies to.
-    example:
-      "@type": xdm:descriptorIdentity
-      xdm:sourceSchema: https://ns.adobe.com/{TENANT_ID}/schemas/5b8d40b434bec502955d3e0144c4ce14d096897c6b0ca11f
-      xdm:sourceVersion: 1
-      xdm:sourceProperty: "/homeAddress"
-      xdm:description:
-        en_us: The home address for the customer.
-  createDescriptorResponse:
-    allOf:
-      - $ref: '#/definitions/basicDescriptorDetails'
-      - $ref: '#/definitions/descriptorOrgAndVersion'
-      - $ref: '#/definitions/resourceContainers'
-    example:
-      "@id": 557ab9db09a9451820c1dca6b8bc13473695ac63c56934eb
-      "@type": xdm:alternateDisplayInfo
-      xdm:sourceSchema: https://ns.adobe.com/{TENANT_ID}/schemas/5b8d40b434bec502955d3e0144c4ce14d096897c6b0ca11f
-      xdm:sourceVersion: 1
-      xdm:sourceProperty: "/homeAddress"
-      imsOrg: '{IMS_ORG}'
-      version: '1'
-      xdm:description:
-        en_us: The home address for the customer.
-      meta:containerId: tenant
-      meta:sandboxId: 36ac3b60-e3df-11e9-8f5d-7f27416c5f0d
-      meta:sandboxType: production
-  importExportPayload:
-    type: array
-    items:
-      type: object
-    example:
-      - "$id": "https://ns.adobe.com/<XDM_TENANTID_PLACEHOLDER>/mixins/443fe51457047d958f4a97853e64e0eca93ef34d7990583b"
-        "meta:altId": "_<XDM_TENANTID_PLACEHOLDER>.mixins.443fe51457047d958f4a97853e64e0eca93ef34d7990583b"
-        "meta:resourceType": "mixins"
-        "version": "1.0"
-        "title": "Example field group"
-        "type": "object"
-        "description": ""
-        "definitions":
-          "customFields":
-            "type": "object"
-            "properties":
-                "_<XDM_TENANTID_PLACEHOLDER>":
-                    "type": "object"
-                    "properties":
-                        "customerId":
-                            "title": "Customer ID"
-                            "description": ""
-                            "type": "string"
-                            "isRequired": false
-                            "meta:xdmType": "string"
-                    "meta:xdmType": "object"
-          "meta:xdmType": "object"
-        "allOf":
-          - "$ref": "#/definitions/customFields"
-            "type": "object"
-            "meta:xdmType": "object"
-        "meta:extensible": true
-        "meta:abstract": true
-        "meta:intendedToExtend": []
-        "meta:xdmType": "object"
-        "meta:sandboxId": "ff0f6870-c46d-11e9-8ca3-036939a64204"
-        "meta:sandboxType": "production"
-      - "$id": "https://ns.adobe.com/<XDM_TENANTID_PLACEHOLDER>/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117c80"
-        "meta:altId": "_<XDM_TENANTID_PLACEHOLDER>.schemas.20af3f1d4b175f27ba59529d1b51a0c79fc25df454117c80"
-        "meta:resourceType": "schemas"
-        "version": "1.1"
-        "title": "Example schema"
-        "type": "object"
-        "description": ""
-        "allOf":
-          - "$ref": "https://ns.adobe.com/xdm/context/profile"
-            "type": "object"
-            "meta:xdmType": "object"
-          - "$ref": "https://ns.adobe.com/<XDM_TENANTID_PLACEHOLDER>/mixins/443fe51457047d958f4a97853e64e0eca93ef34d7990583b"
-            "type": "object"
-            "meta:xdmType": "object"
-        "meta:extensible": false
-        "meta:abstract": false
-        "meta:extends":
-          - "https://ns.adobe.com/<XDM_TENANTID_PLACEHOLDER>/mixins/443fe51457047d958f4a97853e64e0eca93ef34d7990583b"
-          - "https://ns.adobe.com/xdm/common/auditable"
-          - "https://ns.adobe.com/xdm/data/record"
-          - "https://ns.adobe.com/xdm/context/profile"
-        "meta:xdmType": "object"
-        "meta:class": "https://ns.adobe.com/xdm/context/profile"
-        "meta:sandboxId": "ff0f6870-c46d-11e9-8ca3-036939a64204"
-        "meta:sandboxType": "production"
-  importResponse:
-    type: array
-    items:
-      type: object
-    example:
-      - "$id": "https://ns.adobe.com/{TENANT_ID}/mixins/443fe51457047d958f4a97853e64e0eca93ef34d7990583b"
-        "meta:altId": "_{TENANT_ID}.mixins.443fe51457047d958f4a97853e64e0eca93ef34d7990583b"
-        "meta:resourceType": "mixins"
-        "version": "1.0"
-        "title": "Example field group"
-        "type": "object"
-        "description": ""
-        "definitions":
-          "customFields":
-            "type": "object"
-            "properties":
-                "_{TENANT_ID}":
-                    "type": "object"
-                    "properties":
-                        "customerId":
-                            "title": "Customer ID"
-                            "description": ""
-                            "type": "string"
-                            "isRequired": false
-                            "meta:xdmType": "string"
-                    "meta:xdmType": "object"
-          "meta:xdmType": "object"
-        "allOf":
-          - "$ref": "#/definitions/customFields"
-            "type": "object"
-            "meta:xdmType": "object"
-        "meta:extensible": true
-        "meta:abstract": true
-        "meta:intendedToExtend": []
-        "meta:xdmType": "object"
-        "meta:sandboxId": "ff0f6870-c46d-11e9-8ca3-036939a64204"
-        "meta:sandboxType": "production"
-      - "$id": "https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117c80"
-        "meta:altId": "_{TENANT_ID}.schemas.20af3f1d4b175f27ba59529d1b51a0c79fc25df454117c80"
-        "meta:resourceType": "schemas"
-        "version": "1.1"
-        "title": "Example schema"
-        "type": "object"
-        "description": ""
-        "allOf":
-          - "$ref": "https://ns.adobe.com/xdm/context/profile"
-            "type": "object"
-            "meta:xdmType": "object"
-          - "$ref": "https://ns.adobe.com/{TENANT_ID}/mixins/443fe51457047d958f4a97853e64e0eca93ef34d7990583b"
-            "type": "object"
-            "meta:xdmType": "object"
-        "meta:extensible": false
-        "meta:abstract": false
-        "meta:extends":
-          - "https://ns.adobe.com/{TENANT_ID}/mixins/443fe51457047d958f4a97853e64e0eca93ef34d7990583b"
-          - "https://ns.adobe.com/xdm/common/auditable"
-          - "https://ns.adobe.com/xdm/data/record"
-          - "https://ns.adobe.com/xdm/context/profile"
-        "meta:xdmType": "object"
-        "meta:class": "https://ns.adobe.com/xdm/context/profile"
-        "meta:sandboxId": "ff0f6870-c46d-11e9-8ca3-036939a64204"
-        "meta:sandboxType": "production"
-  customFields:
-    type: object
-    properties:
-      $ref:
-        type: string
-        example: '#/definitions/customFields'
-      "type":
-        type: string
-        example: "object"
-      "meta:xdmType":
-        type: string
-        example: "object"
-  importError:
-    type: object
-    example:
-      "type": "http://ns.adobe.com/aep/errors/XDM-3005-400"
-      "title": "Import Resource Failed"
-      "status": 400
-      "report":
-        "registryRequestId": "1c282c30-d6ca-40a3-a694-e914a12f249d"
-        "timestamp": "10-22-2020 06:33:12"
-        "detailed-message": "Failed to import resources. Error: Title must be unique. An object https://ns.adobe.com/{TENANT_ID}/mixins/443fe51457047d958f4a97853e64e0eca93ef34d7990583b already exists with the same title"
-        "sub-errors": []
-      "detail": "Failed to import resources. Error: Title must be unique. An object https://ns.adobe.com/{TENANT_ID}/mixins/443fe51457047d958f4a97853e64e0eca93ef34d7990583b already exists with the same title"
-  notFoundError:
-    type: object
-    example:
-      "type": "http://ns.adobe.com/aep/errors/XDM-1012-404"
-      "title": "Resource Not Found"
-      "status": 404
-      "report":
-        "registryRequestId": "a6773f98-f5ba-4e3e-8ff8-320136cc6c48"
-        "timestamp": "10-22-2020 06:42:13"
-        "detailed-message": "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
-      "detail": "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117 with version 1 is not found"
-  record:
-    type: string
-    example: "#/definitions/record"
-  loyalty:
-    type: string
-    example: "#/definitions/loyalty"
-  profile-person-details:
-    type: string
-    example: '#/definitions/profile-person-details'
-  acceptErrorList:
-    allOf:
-      - $ref: '#/definitions/errorBasic'
-    example:
-      "type": "http://ns.adobe.com/aep/errors/XDM-1006-400"
-      "title": "Accept header invalid"
-      "status": 400
-      "report":
-        "registryRequestId": "d2550d48-95f5-43ee-adb7-1035bf9d3258"
-        "timestamp": "11-25-2020 07:56:25"
-        "detailed-message": "The supplied Accept header is not valid: application/vnd.adobe.xed+json;version=1 - A valid Accept value should look like application/vnd.adobe.'{xed|xdm'}+json"
-        "sub-errors": []
-      "detail": "The supplied Accept header is not valid: application/vnd.adobe.xed+json;version=1 - A valid Accept value should look like application/vnd.adobe.'{xed|xdm'}+json"
-  acceptErrorLookup:
-    allOf:
-      - $ref: '#/definitions/errorBasic'
-    example:
-      type: http://ns.adobe.com/aep/errors/XDM-1007-400
-      title: Accept header invalid
-      status: 400
-      report:
-        registryRequestId: fc4f81b7-d0aa-4116-a0e1-e6f9c82b6470
-        timestamp: 11-02-2021 07:42:43
-        detailed-message: 'The supplied Accept header is not valid: application/vnd.adobe.xed+json
-          - A valid Accept value should look like application/vnd.adobe.''{xed|xdm''}+json;
-          version=1 (Version should be specified)'
-        sub-errors: []
-      detail: 'The supplied Accept header is not valid: application/vnd.adobe.xed+json -
-        A valid Accept value should look like application/vnd.adobe.''{xed|xdm''}+json;
-        version=1 (Version should be specified)'
-  acceptErrorDescriptorList:
-    allOf:
-      - $ref: '#/definitions/errorBasic'
-    example:
-      type: http://ns.adobe.com/aep/errors/XDM-1008-400
-      title: Accept header invalid
-      status: 400
-      report:
-        registryRequestId: c9b7df97-10bf-4a82-b139-2926a6585172
-        timestamp: 11-05-2021 07:16:36
-        detailed-message: 'The supplied Accept header is not valid: application/vnd.adobe.xed+json
-          - A valid Accept value should look like application/vnd.adobe.xdm-id+json'
-        sub-errors: []
-      detail: 'The supplied Accept header is not valid: application/vnd.adobe.xed+json -
-        A valid Accept value should look like application/vnd.adobe.xdm-id+json'
-  acceptErrorDescriptorLookup:
-    allOf:
-      - $ref: '#/definitions/errorBasic'
-    example:
-      type: http://ns.adobe.com/aep/errors/XDM-1009-400
-      title: Accept header invalid
-      status: 400
-      report:
-        registryRequestId: 4f016ac4-46c8-45cd-aeb8-59b52d46462f
-        timestamp: 11-05-2021 07:17:57
-        detailed-message: 'The supplied Accept header is not valid: application/vnd.adobe.xed+json;version=1
-          - A valid Accept value should look like application/vnd.adobe.xdm+json'
-        sub-errors: []
-      detail: 'The supplied Accept header is not valid: application/vnd.adobe.xed+json;version=1
-        - A valid Accept value should look like application/vnd.adobe.xdm+json'
-
-  errorBasic:
-    type: object
-    properties:
-      type:
-        type: string
-        description: The XDM error code.
-      title:
-        type: string
-        description: The error code title.
-      status:
-        type: integer
-        description: The HTTP status code for the error.
-      report:
+        xdm:sourceSchema:
+          type: string
+          description: The URI `$id` of the schema that this descriptor applies to.
+        xdm:sourceVersion:
+          type: string
+          description: The latest major version of the `sourceSchema`.
+        xdm:sourceProperty:
+          type: string
+          description: The path to the field within the `sourceSchema` that this descriptor
+            applies to.
+      example:
+        '@type': xdm:descriptorIdentity
+        xdm:sourceSchema: "https://ns.adobe.com/{TENANT_ID}/schemas/5b8d40b434bec502955d3e0144c4ce14d096897c6b0ca11f"
+        xdm:sourceVersion: 1
+        xdm:sourceProperty: /homeAddress
+        xdm:description:
+          en_us: The home address for the customer.
+    createDescriptorResponse:
+      allOf:
+      - $ref: '#/components/schemas/basicDescriptorDetails'
+      - $ref: '#/components/schemas/descriptorOrgAndVersion'
+      - $ref: '#/components/schemas/resourceContainers'
+    importExportPayload:
+      type: array
+      example:
+      - $id: https://ns.adobe.com/<XDM_TENANTID_PLACEHOLDER>/mixins/443fe51457047d958f4a97853e64e0eca93ef34d7990583b
+        meta:altId: _<XDM_TENANTID_PLACEHOLDER>.mixins.443fe51457047d958f4a97853e64e0eca93ef34d7990583b
+        meta:resourceType: mixins
+        version: "1.0"
+        title: Example field group
         type: object
-        description: Contains registry information about the error.
+        description: ""
+        definitions:
+          customFields:
+            type: object
+            properties:
+              _<XDM_TENANTID_PLACEHOLDER>:
+                type: object
+                properties:
+                  customerId:
+                    title: Customer ID
+                    description: ""
+                    type: string
+                    isRequired: false
+                    meta:xdmType: string
+                meta:xdmType: object
+          meta:xdmType: object
+        allOf:
+        - "$ref ": '#/definitions/customFields'
+          type: object
+          meta:xdmType: object
+        meta:extensible: true
+        meta:abstract: true
+        meta:intendedToExtend: []
+        meta:xdmType: object
+        meta:sandboxId: ff0f6870-c46d-11e9-8ca3-036939a64204
+        meta:sandboxType: production
+      - $id: https://ns.adobe.com/<XDM_TENANTID_PLACEHOLDER>/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117c80
+        meta:altId: _<XDM_TENANTID_PLACEHOLDER>.schemas.20af3f1d4b175f27ba59529d1b51a0c79fc25df454117c80
+        meta:resourceType: schemas
+        version: "1.1"
+        title: Example schema
+        type: object
+        description: ""
+        allOf:
+        - $ref: https://ns.adobe.com/xdm/context/profile
+          type: object
+          meta:xdmType: object
+        - $ref: https://ns.adobe.com/<XDM_TENANTID_PLACEHOLDER>/mixins/443fe51457047d958f4a97853e64e0eca93ef34d7990583b
+          type: object
+          meta:xdmType: object
+        meta:extensible: false
+        meta:abstract: false
+        meta:extends:
+        - https://ns.adobe.com/<XDM_TENANTID_PLACEHOLDER>/mixins/443fe51457047d958f4a97853e64e0eca93ef34d7990583b
+        - https://ns.adobe.com/xdm/common/auditable
+        - https://ns.adobe.com/xdm/data/record
+        - https://ns.adobe.com/xdm/context/profile
+        meta:xdmType: object
+        meta:class: https://ns.adobe.com/xdm/context/profile
+        meta:sandboxId: ff0f6870-c46d-11e9-8ca3-036939a64204
+        meta:sandboxType: production
+      items:
+        type: object
+        properties: {}
+    importResponse:
+      type: array
+      example:
+      - $id: "https://ns.adobe.com/{TENANT_ID}/mixins/443fe51457047d958f4a97853e64e0eca93ef34d7990583b"
+        meta:altId: "_{TENANT_ID}.mixins.443fe51457047d958f4a97853e64e0eca93ef34d7990583b"
+        meta:resourceType: mixins
+        version: "1.0"
+        title: Example field group
+        type: object
+        description: ""
+        definitions:
+          customFields:
+            type: object
+            properties:
+              _{TENANT_ID}:
+                type: object
+                properties:
+                  customerId:
+                    title: Customer ID
+                    description: ""
+                    type: string
+                    isRequired: false
+                    meta:xdmType: string
+                meta:xdmType: object
+          meta:xdmType: object
+        allOf:
+        - "$ref ": '#/definitions/customFields'
+          type: object
+          meta:xdmType: object
+        meta:extensible: true
+        meta:abstract: true
+        meta:intendedToExtend: []
+        meta:xdmType: object
+        meta:sandboxId: ff0f6870-c46d-11e9-8ca3-036939a64204
+        meta:sandboxType: production
+      - $id: "https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117c80"
+        meta:altId: "_{TENANT_ID}.schemas.20af3f1d4b175f27ba59529d1b51a0c79fc25df454117c80"
+        meta:resourceType: schemas
+        version: "1.1"
+        title: Example schema
+        type: object
+        description: ""
+        allOf:
+        - "$ref ": https://ns.adobe.com/xdm/context/profile
+          type: object
+          meta:xdmType: object
+        - "$ref ": "https://ns.adobe.com/{TENANT_ID}/mixins/443fe51457047d958f4a97853e64e0eca93ef34d7990583b"
+          type: object
+          meta:xdmType: object
+        meta:extensible: false
+        meta:abstract: false
+        meta:extends:
+        - "https://ns.adobe.com/{TENANT_ID}/mixins/443fe51457047d958f4a97853e64e0eca93ef34d7990583b"
+        - https://ns.adobe.com/xdm/common/auditable
+        - https://ns.adobe.com/xdm/data/record
+        - https://ns.adobe.com/xdm/context/profile
+        meta:xdmType: object
+        meta:class: https://ns.adobe.com/xdm/context/profile
+        meta:sandboxId: ff0f6870-c46d-11e9-8ca3-036939a64204
+        meta:sandboxType: production
+      items:
+        type: object
+        properties: {}
+    customFields:
+      type: object
+      properties:
+        $ref:
+          type: string
+          example: '#/definitions/customFields'
+        type:
+          type: string
+          example: object
+        meta:xdmType:
+          type: string
+          example: object
+    importError:
+      type: object
+      example:
+        type: http://ns.adobe.com/aep/errors/XDM-3005-400
+        title: Import Resource Failed
+        status: 400
+        report:
+          registryRequestId: 1c282c30-d6ca-40a3-a694-e914a12f249d
+          timestamp: 10-22-2020 06:33:12
+          detailed-message: "Failed to import resources. Error: Title must be unique.\
+            \ An object https://ns.adobe.com/{TENANT_ID}/mixins/443fe51457047d958f4a97853e64e0eca93ef34d7990583b\
+            \ already exists with the same title"
+          sub-errors: []
+        detail: "Failed to import resources. Error: Title must be unique. An object\
+          \ https://ns.adobe.com/{TENANT_ID}/mixins/443fe51457047d958f4a97853e64e0eca93ef34d7990583b\
+          \ already exists with the same title"
+    notFoundError:
+      type: object
+      example:
+        type: http://ns.adobe.com/aep/errors/XDM-1012-404
+        title: Resource Not Found
+        status: 404
+        report:
+          registryRequestId: a6773f98-f5ba-4e3e-8ff8-320136cc6c48
+          timestamp: 10-22-2020 06:42:13
+          detailed-message: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117\
+            \ with version 1 is not found"
+        detail: "Requested resource https://ns.adobe.com/{TENANT_ID}/schemas/20af3f1d4b175f27ba59529d1b51a0c79fc25df454117\
+          \ with version 1 is not found"
+    record:
+      type: string
+      example: '#/definitions/record'
+    loyalty:
+      type: string
+      example: '#/definitions/loyalty'
+    profile-person-details:
+      type: string
+      example: '#/definitions/profile-person-details'
+    acceptErrorList:
+      allOf:
+      - $ref: '#/components/schemas/errorBasic'
+    acceptErrorLookup:
+      allOf:
+      - $ref: '#/components/schemas/errorBasic'
+    acceptErrorDescriptorList:
+      allOf:
+      - $ref: '#/components/schemas/errorBasic'
+    acceptErrorDescriptorLookup:
+      allOf:
+      - $ref: '#/components/schemas/errorBasic'
+    errorBasic:
+      type: object
+      properties:
+        type:
+          type: string
+          description: The XDM error code.
+        title:
+          type: string
+          description: The error code title.
+        status:
+          type: integer
+          description: The HTTP status code for the error.
+        report:
+          type: object
+          properties:
+            registryRequestId:
+              type: string
+              description: A unique ID for the report.
+            timestamp:
+              type: string
+              description: A timestamp of when the error occurred.
+            detailed-message:
+              type: string
+              description: A detailed message about what caused the error.
+            sub-errors:
+              type: array
+              description: Contains details about other errors that this error is
+                a parent of.
+              items:
+                $ref: '#/components/schemas/errorBasic'
+          description: Contains registry information about the error.
+        detail:
+          type: string
+          description: A detailed message about what caused the error.
+    friendlyNameDescriptorResponse:
+      allOf:
+      - $ref: '#/components/schemas/basicDescriptorDetails'
+      - $ref: '#/components/schemas/descriptorOrgAndVersion'
+      - type: object
         properties:
-          registryRequestId:
-            type: string
-            description: A unique ID for the report.
-          timestamp:
-            type: string
-            description: A timestamp of when the error occurred.
-          detailed-message:
-            type: string
-            description: A detailed message about what caused the error.
-          sub-errors:
-            type: array
-            description: Contains details about other errors that this error is a parent of.
-            items:
-              $ref: '#/definitions/errorBasic'
-      detail:
-        type: string
-        description: A detailed message about what caused the error.
-  friendlyNameDescriptorResponse:
-    allOf:
-      - $ref: '#/definitions/basicDescriptorDetails'
-      - $ref: '#/definitions/descriptorOrgAndVersion'
-      - properties:
           xdm:title:
             type: string
-            description: The alternate display title that the descriptor applies to the target field (`sourceProperty`).
+            description: The alternate display title that the descriptor applies to
+              the target field (`sourceProperty`).
           xdm:description:
             type: string
-            description: The alternate description that the descriptor applies to the target field (`sourceProperty`).
-      - $ref: '#/definitions/resourceContainers'
-      - $ref: '#/definitions/metaRegistryMetadata'
-    example:
-      "@id": 6acc5b7c0fc15159463ac1f1dbcb0c5950f330f2db740105
-      "@type": xdm:alternateDisplayInfo
-      xdm:sourceSchema: https://ns.adobe.com/{TENANT_ID}/schemas/4177bdbd4b2b328061bdd077dce25ea020b80d5c208553e0
-      xdm:sourceVersion: 1
-      xdm:sourceProperty: "/_experience/analytics/customDimensions/eVars/eVar1"
-      imsOrg: '{IMS_ORG}'
-      version: '1'
-      xdm:title:
-        en_us: Internal Campaign
-      xdm:description:
-        en_us: Internal campaign eVar.
-      meta:containerId: tenant
-      meta:sandboxId: 28e74200-e3de-11e9-8f5d-7f27416c5f0d
-      meta:sandboxType: production
-      meta:registryMetadata:
-        repo:createdDate: 1611685171098
-        repo:lastModifiedDate: 1611685171098
-        xdm:createdClientId: '{CLIENT_ID}'
-        xdm:lastModifiedClientId: '{CLIENT_ID}'
-        xdm:createdUserId: '{USER_ID}'
-        xdm:lastModifiedUserId: '{USER_ID}'
-        eTag: 6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b
-
-  identityDescriptorResponse:
-    allOf:
-      - $ref: '#/definitions/basicDescriptorDetails'
-      - $ref: '#/definitions/descriptorOrgAndVersion'
-      - properties:
+            description: The alternate description that the descriptor applies to
+              the target field (`sourceProperty`).
+      - $ref: '#/components/schemas/resourceContainers'
+      - $ref: '#/components/schemas/metaRegistryMetadata'
+    identityDescriptorResponse:
+      allOf:
+      - $ref: '#/components/schemas/basicDescriptorDetails'
+      - $ref: '#/components/schemas/descriptorOrgAndVersion'
+      - type: object
+        properties:
           xdm:namespace:
             type: string
-            description: The [identity namespace](https://experienceleague.adobe.com/docs/experience-platform/identity/namespaces.html) that this descriptor applies to the target field (`sourceProperty`). An identity namespace can be referenced using its string-based `code` value (e.g. `Email`) or its corresponding integer `id` (e.g. `6`).
+            description: "The [identity namespace](https://experienceleague.adobe.com/docs/experience-platform/identity/namespaces.html)\
+              \ that this descriptor applies to the target field (`sourceProperty`).\
+              \ An identity namespace can be referenced using its string-based `code`\
+              \ value (e.g. `Email`) or its corresponding integer `id` (e.g. `6`)."
           xdm:property:
             type: string
-            description: If `xdm:namespace` uses the namespace's string-based identifier, this value should be set to `xdm:code`. If `xdm:namespace` uses the namespace's integer ID, this value should be set to `xdm:id`.
+            description: "If `xdm:namespace` uses the namespace's string-based identifier,\
+              \ this value should be set to `xdm:code`. If `xdm:namespace` uses the\
+              \ namespace's integer ID, this value should be set to `xdm:id`."
           xdm:isPrimary:
             type: boolean
-            description: Indicates whether this target field (`sourceProperty`) represents the primary identity for the target schema (`sourceSchema`).
-      - $ref: '#/definitions/resourceContainers'
-      - $ref: '#/definitions/metaRegistryMetadata'
-    example:
-      "@id": 8f52618ac104afa0da2b1d7c1cc8ac4a0da66a53
-      "@type": xdm:descriptorIdentity
-      xdm:sourceSchema: https://ns.adobe.com/{TENANT_ID}/schemas/837ea89d1103906bf6f2710064ae40b1
-      xdm:sourceVersion: 1
-      xdm:sourceProperty: "/personalEmail/address"
-      imsOrg: '{IMS_ORG}'
-      version: '1'
-      xdm:namespace: Email
-      xdm:property: xdm:code
-      xdm:isPrimary: true
-      meta:containerId: tenant
-      meta:sandboxId: 28e74200-e3de-11e9-8f5d-7f27416c5f0d
-      meta:sandboxType: production
-      meta:registryMetadata:
-        repo:createdDate: 1556055659091
-        repo:lastModifiedDate: 1556055659091
-        xdm:createdClientId: '{CLIENT_ID}'
-        xdm:createdUserId: '{USER_ID}'
-        xdm:lastModifiedUserId: '{USER_ID}'
-        eTag: 6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b
-
-  referenceDescriptorResponse:
-    allOf:
-      - $ref: '#/definitions/basicDescriptorDetails'
-      - $ref: '#/definitions/descriptorOrgAndVersion'
-      - properties:
+            description: Indicates whether this target field (`sourceProperty`) represents
+              the primary identity for the target schema (`sourceSchema`).
+      - $ref: '#/components/schemas/resourceContainers'
+      - $ref: '#/components/schemas/metaRegistryMetadata'
+    referenceDescriptorResponse:
+      allOf:
+      - $ref: '#/components/schemas/basicDescriptorDetails'
+      - $ref: '#/components/schemas/descriptorOrgAndVersion'
+      - type: object
+        properties:
           xdm:identityNamespace:
             type: string
-            description: The [identity namespace](https://experienceleague.adobe.com/docs/experience-platform/identity/namespaces.html) of the destination schema's primary identity field, which the target field (`sourceProperty`) in the source schema references.
-      - $ref: '#/definitions/resourceContainers'
-      - $ref: '#/definitions/metaRegistryMetadata'
-    example:
-      "@id": bde9eb256ec3ddb51491459d00ddd4e0c3b03d16
-      "@type": xdm:descriptorReferenceIdentity
-      xdm:sourceSchema: https://ns.adobe.com/{TENANT_ID}/schemas/e7bc97acfaf14832fd666cbd6b3629e1
-      xdm:sourceVersion: 1
-      xdm:sourceProperty: "/_{TENANT_ID}/favoriteProduct"
-      imsOrg: '{IMS_ORG}'
-      version: '1'
-      xdm:identityNamespace: productID
-      meta:containerId: tenant
-      meta:sandboxId: 28e74200-e3de-11e9-8f5d-7f27416c5f0d
-      meta:sandboxType: production
-      meta:registryMetadata:
-        repo:createdDate: 1570569826581
-        repo:lastModifiedDate: 1570569826581
-        xdm:createdClientId: '{CLIENT_ID}'
-        xdm:lastModifiedClientId: '{CLIENT_ID}'
-        xdm:createdUserId: '{USER_ID}'
-        xdm:lastModifiedUserId: '{USER_ID}'
-        eTag: 6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b
-  relationshipDescriptorResponse:
-    allOf:
-      - $ref: '#/definitions/basicDescriptorDetails'
-      - properties:
+            description: "The [identity namespace](https://experienceleague.adobe.com/docs/experience-platform/identity/namespaces.html)\
+              \ of the destination schema's primary identity field, which the target\
+              \ field (`sourceProperty`) in the source schema references."
+      - $ref: '#/components/schemas/resourceContainers'
+      - $ref: '#/components/schemas/metaRegistryMetadata'
+    relationshipDescriptorResponse:
+      allOf:
+      - $ref: '#/components/schemas/basicDescriptorDetails'
+      - type: object
+        properties:
           xdm:destinationSchema:
             type: string
             description: The `$id` of the destination schema in the relationship.
           xdm:destinationVersion:
             type: string
-            description: The latest major version of the destination schema in the relationship.
-      - $ref: '#/definitions/descriptorOrgAndVersion'
-      - $ref: '#/definitions/resourceContainers'
-      - $ref: '#/definitions/metaRegistryMetadata'
-    example:
-      "@id": 11b03201c4cbc99f99abe33523d49cc24a636330
-      "@type": xdm:descriptorOneToOne
-      xdm:sourceSchema: https://ns.adobe.com/{TENANT_ID}/schemas/e7bc97acfaf14832fd666cbd6b3629e1
-      xdm:sourceVersion: 1
-      xdm:sourceProperty: "/_{TENANT_ID}/favoriteProduct"
-      xdm:destinationSchema: https://ns.adobe.com/{TENANT_ID}/schemas/74ec84c38fefa486bc81c03a172933f1
-      xdm:destinationVersion: 1
-      imsOrg: '{IMS_ORG}'
-      version: '1'
-      meta:containerId: tenant
-      meta:sandboxId: 28e74200-e3de-11e9-8f5d-7f27416c5f0d
-      meta:sandboxType: production
-      meta:registryMetadata:
-        repo:createdDate: 1570569826248
-        repo:lastModifiedDate: 1570569826248
-        xdm:createdClientId: '{CLIENT_ID}'
-        xdm:lastModifiedClientId: '{CLIENT_ID}'
-        xdm:createdUserId: '{USER_ID}'
-        xdm:lastModifiedUserId: '{USER_ID}'
-        eTag: 6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b
-  basicDescriptorDetails:
-    allOf:
-      - properties:
+            description: The latest major version of the destination schema in the
+              relationship.
+      - $ref: '#/components/schemas/descriptorOrgAndVersion'
+      - $ref: '#/components/schemas/resourceContainers'
+      - $ref: '#/components/schemas/metaRegistryMetadata'
+    basicDescriptorDetails:
+      allOf:
+      - type: object
+        properties:
           '@id':
             type: string
             description: The unique ID for the descriptor.
-      - $ref: '#/definitions/createDescriptor'
-  descriptorOrgAndVersion:
-    type: object
-    properties:
-      imsOrg:
+      - $ref: '#/components/schemas/createDescriptor'
+    descriptorOrgAndVersion:
+      type: object
+      properties:
+        imsOrg:
+          type: string
+          description: The ID of the IMS Organization that owns this descriptor.
+        version:
+          type: string
+          description: The current major version of the descriptor.
+  parameters:
+    containerIdList:
+      name: CONTAINER_ID
+      in: path
+      description: "The name of the container that you want to list resources from.\
+        \ To list core resources provided by Adobe, use `global`. To list custom resources\
+        \ defined by your organization, use `tenant`."
+      required: true
+      schema:
         type: string
-        description: The ID of the IMS Organization that owns this descriptor.
-      version:
+    containerIdLookup:
+      name: CONTAINER_ID
+      in: path
+      description: "The name of the container that you want to retrieve a resource\
+        \ from. To retrieve a core resource provided by Adobe, use `global`. To retrieve\
+        \ a custom resource defined by your organization, use `tenant`."
+      required: true
+      schema:
         type: string
-        description: The current major version of the descriptor.
+    SCHEMA_ID:
+      name: SCHEMA_ID
+      in: path
+      description: The `meta:altId` or URL-encoded `$id` of the schema in question.
+      required: true
+      schema:
+        type: string
+    BEHAVIOR_ID:
+      name: BEHAVIOR_ID
+      in: path
+      description: The `meta:altId` or URL-encoded `$id` of the behavior in question.
+      required: true
+      schema:
+        type: string
+    CLASS_ID:
+      name: CLASS_ID
+      in: path
+      description: The `meta:altId` or URL-encoded `$id` of the class in question.
+      required: true
+      schema:
+        type: string
+    MIXIN_ID:
+      name: MIXIN_ID
+      in: path
+      description: The `meta:altId` or URL-encoded `$id` of the mixin in question.
+      required: true
+      schema:
+        type: string
+    DATA_TYPE_ID:
+      name: DATA_TYPE_ID
+      in: path
+      description: The `meta:altId` or URL-encoded `$id` of the data type in question.
+      required: true
+      schema:
+        type: string
+    DESCRIPTOR_ID:
+      name: DESCRIPTOR_ID
+      in: path
+      description: The unique ID (`@id`) of the descriptor in question.
+      required: true
+      schema:
+        type: string
+    UNION_ID:
+      name: UNION_ID
+      in: path
+      description: The `meta:altId` or URL-encoded `$id` of the union schema in question.
+      required: true
+      schema:
+        type: string
+    authorization:
+      name: Authorization
+      in: header
+      description: "The access token which can be copied from your Experience Platform\
+        \ integration, prefixed with \"Bearer \". For more information on how to obtain\
+        \ this value, visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+      required: true
+      schema:
+        type: string
+    x-gw-ims-org-id:
+      name: x-gw-ims-org-id
+      in: header
+      description: "The IMS Organization ID which can be copied from your Experience\
+        \ Platform integration. For more information on how to obtain this value,\
+        \ visit the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+      required: true
+      schema:
+        type: string
+    x-api-key:
+      name: x-api-key
+      in: header
+      description: "The API key which can be copied from your Experience Platform\
+        \ integration. For more information on how to obtain this value, visit the\
+        \ [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en)."
+      required: true
+      schema:
+        type: string
+    x-sandbox-name:
+      name: x-sandbox-name
+      in: header
+      description: "The name of the sandbox in which the operation will take place.\
+        \ See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for\
+        \ more information."
+      required: true
+      schema:
+        type: string
+    content-type:
+      name: Content-Type
+      in: header
+      description: "The type of content being sent in the body of the request. When\
+        \ sending requests that include payloads to the Schema Registry API, this\
+        \ header must be included with a value of `application/json`."
+      required: true
+      schema:
+        type: string
+    accept:
+      name: Accept
+      in: header
+      description: |-
+        The desired response format. For lookup requests, a `version` parameter must be included, with the following `Accept` header values being permitted:
+        <table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed+json; version=1</code></td><td>Returns only the basic details of the resource, with all inherited fields relegated to <code>$ref</code> and <code>allOf</code> properties.</td></tr><tr><td><code>application/vnd.adobe.xed-full+json; version=1</code></td><td>Returns the full details of the resource, including the details all fields inherited from other resources.</td></tr><tr><td><code>application/vnd.adobe.xed-notext+json; version=1</code></td><td>Returns only the basic details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-notext+json; version=1</code></td><td>Returns the full details of the resource, but with no titles or descriptions.</td></tr><tr><td><code>application/vnd.adobe.xed-full-desc+json; version=1</code></td><td>Returns the full details of the resource, including descriptions but with no titles.</td></tr></tbody></table>
+      required: true
+      schema:
+        type: string
+    acceptListing:
+      name: Accept
+      in: header
+      description: "The desired response format. For listing calls, the following\
+        \ `Accept` header values are permitted: \n<table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xed-id+json</code></td><td>Returns\
+        \ a short summary of each resource, generally the preferred header for listing.</td></tr><tr><td><code>application/vnd.adobe.xed+json</code></td><td>Returns\
+        \ full JSON for each resource, with the original <code>$ref</code> and <code>allOf</code>\
+        \ attributes included.</td></tr></tbody></table>"
+      required: true
+      schema:
+        type: string
+    acceptDescriptors:
+      name: Accept
+      in: header
+      description: |-
+        The desired response format. Descriptors require unique `Accept` headers using `xdm` instead of `xed`. The following values are permitted:
+        <table><thead><tr><th>Accept</th><th>Description</th></tr></thead><tbody><tr><td><code>application/vnd.adobe.xdm-id+json</code></td><td>Returns a list of descriptor IDs, grouped by their <code>@type</code>.</td></tr><tr><td><code>application/vnd.adobe.xdm-link+json</code></td><td>Returns a list of descriptor API paths, grouped by their <code>@type</code>.</td></tr><tr><td><code>application/vnd.adobe.xdm+json</code></td><td>Returns a list of descriptor objects, grouped by their <code>@type</code>.</td></tr><tr><td><code>application/vnd.adobe.xdm-v2{-id/-link}+json</code></td><td>Including the <code>-v2</code> option in any of the above <code>Accept</code> headers permits paging functionality, returning a results array with a <code>_page</code> attribute that can be used to request the next page if needed.</td></tr></tbody></table>
+      required: true
+      schema:
+        type: string
+    property:
+      name: property
+      in: query
+      description: "A comma-separated list of top-level object properties to be returned\
+        \ in the response. For example, `property=meta:intendedToExtend==https://ns.adobe.com/xdm/context/profile`\
+        \ returns only field groups that are compatible with the XDM Individual Profile\
+        \ class."
+      schema:
+        type: string
+    orderBy:
+      name: orderby
+      in: query
+      description: "Sort the listed resources by specified fields. For example `orderby=title`\
+        \ sorts results by title in ascending order (A-Z). Adding a `-` before the\
+        \ field name (`orderby=-title`) sorts items in descending order (Z-A). Multiple\
+        \ fields can also be included to denote primary and secondary sort orders\
+        \ (for example, `orderby=title,description`)."
+      schema:
+        type: string
+    limit:
+      name: limit
+      in: query
+      description: |-
+        When used in conjunction with an `orderby` parameter, `limit` restricts the maximum number of items that should be returned for a given request. This parameter cannot be used without an `orderby` parameter present.
+
+        The `limit` parameter specifies a positive integer (between `0` and `500`) as a *hint* as to the maximum number of items that should be returned. For example, `limit=5` returns only five resources in the list. However, this value is not strictly honored. The actual response size may be smaller or larger as constrained by the need to provide the reliable operation of the `start` parameter, if one is provided.
+      schema:
+        type: number
+    start:
+      name: start
+      in: query
+      description: |-
+        When used in conjunction with an `orderby` parameter, `start` specifies where the paginated list of items should begin. This parameter cannot be used without an `orderby` parameter present.
+
+        Typically, this parameter is omitted in order to obtain the first page of results. After that, `start` should be set to the maximum value of the primary sort property of the `orderby` field received in the previous page. The API response then returns entries beginning with those that have a primary sort property from `orderby` strictly greater than (for ascending) or strictly less than (for descending) the specified value.
+
+        For example, if the `orderby` parameter is set to `orderby=name,firstname`, the `start` parameter would contain a value for the `name` property. In this case, if you wanted to show the next 20 entries of a resource immediately following the name "Miller", you would use: `?orderby=name,firstname&start=Miller&limit=20`.
+      schema:
+        type: string
+  requestBodies:
+    patchPayload:
+      description: The request body accepts a JSON Patch payload.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/patchSchema'
+      required: true
+    patchClassPayload:
+      description: The request body accepts a JSON Patch payload.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/patchClass'
+      required: true
+    patchFieldGroupPayload:
+      description: The request body accepts a JSON Patch payload.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/patchFieldGroup'
+      required: true
+    createSchemaPayload:
+      description: The JSON payload must include an `allOf` attribute referencing
+        the `$id` of the base class the that the schema will implement.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/createSchema'
+      required: true
+    replaceSchemaPayload:
+      description: "The JSON payload must include all of the fields that were originally\
+        \ required for creating the schema, but with updated values. This includes\
+        \ an `allOf` attribute referencing the `$id` of the class the schema will\
+        \ implement."
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/replaceSchema'
+      required: true
+    createClassPayload:
+      description: The request payload must include an `allOf` attribute referencing
+        either 'https://ns.adobe.com/xdm/data/record' or 'https://ns.adobe.com/xdm/data/time-series'.
+        This value represents the data behavior upon which the class is based. `allOf`
+        may also optionally include field groups or custom fields that will be included
+        each time the class is used.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/createClass'
+      required: true
+    replaceClassPayload:
+      description: "The JSON payload must include all of the fields that were originally\
+        \ required for creating the class, but with updated values. This includes\
+        \ an `allOf` attribute referencing the behavior of the class."
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/replaceClass'
+      required: true
+    fieldGroupPayload:
+      description: The JSON payload must include a 'meta:intendedToExtend' field listing
+        the '$id' of the class(es) with which the field group is compatible.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/createFieldGroup'
+      required: true
+    replaceFieldGroupPayload:
+      description: "The JSON payload must include all of the fields that were originally\
+        \ required for creating the field group, but with updated values. This includes\
+        \ an `allOf` attribute referencing the `$id` of the class the schema will\
+        \ implement."
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/replaceFieldGroup'
+      required: true
+    createDataTypePayload:
+      description: |-
+        Unlike field groups, defining a data type does not require `meta:extends` or `meta:intendedToExtend` fields, nor do fields need to be nested to avoid collisions.
+        When it comes to defining the field structure of data type itself, you can use primitive types (like `string` or `object`) or you can reference other existing data types through `$ref` attributes. See the guide on [defining custom XDM fields in the API](../tutorials/custom-fields-api.md) for detailed guidance on the expected format for different XDM field types.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/createDataType'
+      required: true
+    patchDataTypePayload:
+      description: The request body accepts a JSON Patch payload.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/patchDataType'
+      required: true
+    replaceDataTypePayload:
+      description: "The JSON payload must include all of the fields that were originally\
+        \ required for creating the data type, but with updated values."
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/replaceDataType'
+      required: true
+    descriptorPayload:
+      description: "The required request payload fields vary based on the `@type`\
+        \ of descriptor being defined. For details on the requirements for each descriptor\
+        \ type, refer to the section on [defining descriptors](https://experienceleague.adobe.com/docs/experience-platform/xdm/api/descriptors.html?lang=en#defining-descriptors)\
+        \ in the API guide."
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/createDescriptor'
+      required: true
+x-original-swagger-version: "2.0"


### PR DESCRIPTION
Removed errors from the Schema Registry swagger. 
upgraded it to Open API V3

## Description

Had to change some '$ref' to '$ref 'as there was no escape character. $refs are included in in the actual examples and they were creating errors as they did not point to anything.

## Related Issue

https://jira.corp.adobe.com/browse/PLAT-183006

## Motivation and Context

Request by Caleb Kwan 

## How Has This Been Tested?

on editor.swagger.io

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
