### PR TITLE
PLAT-212358: Authentication link updates after Get Credentials implementation

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -17,9 +17,9 @@ Experience Platform services provide RESTful APIs that allow you to programmatic
 
 ### Use the interactive API environment
 
-You can now interact with the Experience Platform API endpoints directly from the API reference pages. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail.
+You can now interact with the Experience Platform API endpoints directly from the API reference pages. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail.
 
-[Learn more](https://experienceleague.adobe.com/en/docs/experience-platform/release-notes/2024/may-2024#interactive-api-documentation)
+[Learn more](https://www.adobe.com/go/platform-api-try-it-en)
 
 <Resources slots="heading, links"/>
 

--- a/static/swagger-specs/access-control.yaml
+++ b/static/swagger-specs/access-control.yaml
@@ -33,7 +33,7 @@ servers:
 
 tags:
 - name: (NEW) Interactive API documentation
-  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Access Control Policies
   description: Access control policies provide information about resources and permissions for the current user. More information about using this set of endpoints can be found in the [access control endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/access-control/api/getting-started.html).
 - name: Attribute Based Access Control Roles

--- a/static/swagger-specs/audit-query.yaml
+++ b/static/swagger-specs/audit-query.yaml
@@ -14,7 +14,7 @@ servers:
         - platform-stage
 tags:
 - name: (NEW) Interactive API documentation
-  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Audit events
   description: Audit events are timestamped records of observed activities in Platform. The API allows you to query events over the last 90 days and create export requests.
 paths:

--- a/static/swagger-specs/batch-ingestion.yaml
+++ b/static/swagger-specs/batch-ingestion.yaml
@@ -50,7 +50,7 @@ servers:
         - platform-stage
 tags:
 - name: (NEW) Interactive API documentation
-  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Batch Ingestion
   description: 'Batch ingestion is used to ingest data into Experience Platform as
     batch files. For example, data being ingested can be the profile data from a flat

--- a/static/swagger-specs/data-access.yaml
+++ b/static/swagger-specs/data-access.yaml
@@ -39,7 +39,7 @@ servers:
           - platform-stage
 tags:
 - name: (NEW) Interactive API documentation
-  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Data Access
   description: Configure data access and egress for Experience Platform.
 - name: Files

--- a/static/swagger-specs/data-prep.yaml
+++ b/static/swagger-specs/data-prep.yaml
@@ -30,7 +30,7 @@ servers:
         - platform-stage
 tags:
 - name: (NEW) Interactive API documentation
-  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Functions
   description: Mapping-set functions allow you to transform your data between source  and destination schemas. You can use these functions to validate your expressions and get a list of all the available mapping-set functions and operations.
 - name: Mapping sets

--- a/static/swagger-specs/dataset-service.yaml
+++ b/static/swagger-specs/dataset-service.yaml
@@ -36,7 +36,7 @@ servers:
         - platform-stage
 tags:
 - name: (NEW) Interactive API documentation
-  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Datasets
   description: "A dataset is a storage and management construct for a collection of data, typically a table, that contains a schema (columns) and fields (rows). Data usage labels can be applied to entire datasets or individual fields within those datasets in order to enforce usage restrictions."
 paths:

--- a/static/swagger-specs/destination-authoring.yaml
+++ b/static/swagger-specs/destination-authoring.yaml
@@ -32,7 +32,7 @@ host: "platform.adobe.io"
 basePath: "/data/core/activation/authoring"
 tags:
   - name: (NEW) Interactive API documentation
-    description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+    description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
   - name: "Destination configurations"
     description: "Destination configurations contain essential metadata for individual destinations, including their name, category, description, and more. The settings in this configuration also determine how Experience Platform users authenticate to your destination, how it appears in the Experience Platform user interface, and the identities that can be exported to your destination. <br><br> For a description of the functionality supported by this endpoint and an example configuration, see the overview on [destination configurations](http://www.adobe.com/go/destination-sdk-destination-configuration-en) in the Destination SDK documentation."
   - name: "Destination servers and templates"

--- a/static/swagger-specs/destinations.yaml
+++ b/static/swagger-specs/destinations.yaml
@@ -52,7 +52,7 @@ tags:
   #           <tr><td>09/07/2022</td><td>Published Destinations Flow Service - API reference</td><td>No</td><td>Initial publish of the API reference documentation to the Adobe Experience Platform developer website.</td></tr>
   #           </tbody></table>
   - name: (NEW) Interactive API documentation
-    description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+    description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
   - name: Glossary
     description: This section describes the terms that you will be encountering in this API documentation. For a complete reference of Experience Platform API terms, read the [Adobe Experience Platform glossary](https://experienceleague.adobe.com/docs/experience-platform/landing/glossary.html).
       <table><thead><tr><th>Term</th><th>Description</th></tr></thead>

--- a/static/swagger-specs/flow-service.yaml
+++ b/static/swagger-specs/flow-service.yaml
@@ -38,7 +38,7 @@ servers:
         - platform-stage
 tags:
 - name: (NEW) Interactive API documentation
-  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Connections
   description: "Base connections retain information between your source and Adobe Experience Platform. They include metadata, a partial view of the credentials used to authenticate a given source, and the unique base connection ID that corresponds to the queried connection. The base connection ID is required to create a source connection. The base connection ID represents your authenticated connection and allows you to explore and inspect the type, structure, and contents of the data that you want to bring to Experience Platform. An instance of a base connection is specific to an organization."
 - name: Connection specs

--- a/static/swagger-specs/observability-insights.yaml
+++ b/static/swagger-specs/observability-insights.yaml
@@ -38,7 +38,7 @@ servers:
         - platform-stage
 tags:
 - name: (NEW) Interactive API documentation
-  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Metrics
   description: Observability metrics are parameters used to gain statistical insights into actions being performed in Adobe Experience Platform. These insights include counts of available Platform resources and statistics on data ingestion.
 paths:

--- a/static/swagger-specs/policy-service.yaml
+++ b/static/swagger-specs/policy-service.yaml
@@ -39,7 +39,7 @@ servers:
         - platform-stage
 tags:
 - name: (NEW) Interactive API documentation
-  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Labels
   description: Data usage labels allow you to categorize datasets and fields according to usage policies that apply to that data.
 - name: Policies

--- a/static/swagger-specs/privacy-service.yaml
+++ b/static/swagger-specs/privacy-service.yaml
@@ -33,7 +33,7 @@ servers:
         - platform-stage
 tags:
 - name: (NEW) Interactive API documentation
-  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Privacy jobs
   description: "Privacy jobs process customer privacy requests, including access/delete and opt-out requests. Each privacy job is tracked under a specific regulation."
 - name: Consent

--- a/static/swagger-specs/profile.yaml
+++ b/static/swagger-specs/profile.yaml
@@ -38,7 +38,7 @@ servers:
         - platform-stage
 tags:
 - name: (NEW) Interactive API documentation
-  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Computed attributes
   description: Computed attributes enable a field value to be automatically computed based on other values, calculations, and expressions. Computed attributes functionality is in **beta** and is **not** available to all users. Functionality is subject to change. For more information on using this set of endpoints, please read the [computed attributes endpoint guide](https://experienceleague.adobe.com/docs/experience-platform/profile/computed-attributes/api.html?lang=en#computed-attributes).
 - name: Entities

--- a/static/swagger-specs/query-service.yaml
+++ b/static/swagger-specs/query-service.yaml
@@ -36,7 +36,7 @@ servers:
         - platform-stage
 tags:
 - name: (NEW) Interactive API documentation
-  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Queries
   description: The queries endpoint uses standard SQL to query data held in Adobe Experience Platform. For example, you can join any number of datasets in the data lake and capture the results as a new dataset.
 - name: Connections

--- a/static/swagger-specs/reactor.yaml
+++ b/static/swagger-specs/reactor.yaml
@@ -23,7 +23,7 @@ servers:
 - url: //reactor.adobe.io
 tags:
 - name: (NEW) Interactive API documentation
-  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Companies
   description: "A company represents the organization of a tags user, typically a business. These companies match 1:1 with IMS Organization IDs. API users will only have visibility into the companies to which they have access. Nearly all API usage is performed using an Adobe I/O integration which is scoped to a single IMS Org, and therefore the /companies endpoint is not a major part of most workflows. Most use cases start with a property instead."
 - name: Properties

--- a/static/swagger-specs/sandbox.yaml
+++ b/static/swagger-specs/sandbox.yaml
@@ -38,7 +38,7 @@ servers:
         - platform-stage
 tags:
 - name: (NEW) Interactive API documentation
-  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Admin operations
   description: "Sandbox operations available only to admins. Sandbox admin privileges are managed through the [Adobe Admin Console](https://adminconsole.adobe.com)."
 - name: User operations

--- a/static/swagger-specs/unified-tags.yaml
+++ b/static/swagger-specs/unified-tags.yaml
@@ -27,7 +27,7 @@ servers:
   - url: https://experience.adobe.io
 tags: 
 - name: (NEW) Interactive API documentation
-  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](http://www.adobe.com/go/platform-api-authentication-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
+  description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Folders
   description: Folders are a capability that let you better organize your business objects for easier navigability and categorization.
 - name: Tags


### PR DESCRIPTION
Updated links to new section in the API authentication guide, documenting how to get your credentials on the API reference pages