### PR TITLE
Update Audit Query Guardrails

### DIFF
--- a/static/swagger-specs/audit-query.yaml
+++ b/static/swagger-specs/audit-query.yaml
@@ -16,7 +16,7 @@ tags:
 - name: (NEW) Interactive API documentation
   description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Audit events
-  description: Audit events are timestamped records of observed activities in Platform. The API allows you to query events over the last 90 days and create export requests.
+  description: Audit events are timestamped records of observed activities in Platform. The API allows you to query events over the last 90 days and create export requests from the last 365 days in 90 day intervals.
 paths:
   /audit/events:
     get:
@@ -57,7 +57,7 @@ paths:
       - name: property
         in: query
         description: |-
-          You can filter list results by including a `property` query parameter. The value must be an array that contains one or more of a list of properties, where each property is prefixed with `property` and seperated with a `?` (for example: `?property=action==create&property=assetType==Sandbox`). If multiple values for the `property` parameter are provided, then all filters must match in order for an event to be returned. Only the last 10,000 records are displayed irrespective of the various filters selected.
+          You can filter list results by including a `property` query parameter. The value must be an array that contains one or more of a list of properties, where each property is prefixed with `property` and seperated with a `?` (for example: `?property=action==create&property=assetType==Sandbox`). If multiple values for the `property` parameter are provided, then all filters must match in order for an event to be returned. Only the last 1000 records are displayed irrespective of the various filters selected.
 
           The properties that can be used for filtering are `type`, `timestamp`, `status`, `action`, `user`, `assetType`, `assetId`, `assetName`, and `requestId`.
 
@@ -74,7 +74,7 @@ paths:
             type: string
       - name: limit
         in: query
-        description: The maximum number of results to return.
+        description: The maximum number of results to return, with a limit of 1000.
         schema:
           type: integer
           format: int32

--- a/static/swagger-specs/audit-query.yaml
+++ b/static/swagger-specs/audit-query.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Audit Query API
   description: "Adobe Experience Platform allows you to audit user activity for various services and capabilities in the form of audit logs. Each action recorded in a log contains metadata that indicates the action type, date and time, the email ID of the user who performed the action, and additional attributes relevant to the action type.\n\nUse the Audit Query API to programmatically view and export audit logs recorded by the system.\n- Related documentation:\n    - [Audit logs overview](https://experienceleague.adobe.com/docs/experience-platform/landing/governance-privacy-security/audit-logs/overview.html)\n\
-    \n- **Visualize API calls with Postman (a free, third-party software)**:\n    - [Audit Query API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Audit%20Query%20API.postman_collection.json)\n    - [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n    - [Steps for importing environments and collections in Postman](https://learning.postman.com/docs/getting-started/importing-and-exporting-data/)\n  \n- **API paths**:\n    - PLATFORM Gateway URL: https://<span>platform.adobe.io/\n    - Base path for this API: /data/foundation\n    - Example of a complete path: https://<span>platform.adobe.io/data/foundation/audit/events\n\n- **Required headers**:\n    - All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).\n    - All resources in Experience Platform are isolated to specific virtual sandboxes. All requests to Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.\n - **API error handling**: \n   - Refer to the Experience Platform API troubleshooting guide for [FAQs](https://experienceleague.adobe.com/docs/experience-platform/landing/troubleshooting.html#faq), [API status codes](https://experienceleague.adobe.com/docs/experience-platform/landing/troubleshooting.html#api-status-codes), and [request header errors](https://experienceleague.adobe.com/docs/experience-platform/landing/troubleshooting.html#request-header-errors)."
+    \n- **Visualize API calls with Postman (a free, third-party software)**:\n    - [Audit Query API Postman collection on GitHub](https://github.com/adobe/experience-platform-postman-samples/blob/master/apis/experience-platform/Audit%20Query%20API.postman_collection.json)\n    - [Video guide for creating the Postman environment](https://video.tv.adobe.com/v/28832)\n    - [Steps for importing environments and collections in Postman](https://learning.postman.com/docs/getting-started/importing-and-exporting-data/)\n  \n- **API paths**:\n    - PLATFORM Gateway URL: https://<span>platform.adobe.io/\n    - Base path for this API: /data/foundation\n    - Example of a complete path: https://<span>platform.adobe.io/data/foundation/audit/events\n\n- **Required headers**:\n    - All calls require the headers `Authorization`, `x-gw-ims-org-id`, and `x-api-key`. For more information on how to obtain these values, see the [authentication tutorial](http://www.adobe.com/go/platform-api-authentication-en).\n    - All resources in Adobe Experience Platform are isolated to specific virtual sandboxes. All requests to Experience Platform APIs require the header `x-sandbox-name` whose value is the all-lowercase name of the sandbox the operation will take place in (for example, \"prod\"). See the [sandboxes overview](https://adobe.com/go/sandbox-overview-en) for more information.\n - **API error handling**: \n   - Refer to the Experience Platform API troubleshooting guide for [FAQs](https://experienceleague.adobe.com/docs/experience-platform/landing/troubleshooting.html#faq), [API status codes](https://experienceleague.adobe.com/docs/experience-platform/landing/troubleshooting.html#api-status-codes), and [request header errors](https://experienceleague.adobe.com/docs/experience-platform/landing/troubleshooting.html#request-header-errors)."
   version: "1.0"
 servers:
 - url: //{environment}.adobe.io/data/foundation
@@ -16,7 +16,7 @@ tags:
 - name: (NEW) Interactive API documentation
   description: You can now interact with the Experience Platform API endpoints directly from this API reference page. Get your [authentication credentials](https://www.adobe.com/go/platform-api-get-credentials-en) and use the **Try it** functionality in the right rail. Note that by using this functionality, you are making real API calls. Keep this in mind when you interact with production sandboxes.
 - name: Audit events
-  description: Audit events are timestamped records of observed activities in Platform. The API allows you to query events over the last 90 days and create export requests from the last 365 days in 90 day intervals.
+  description: Audit events are timestamped records of observed activities in Experience Platform. The API allows you to query events over the last 90 days and create export requests from the last 365 days in 90 day intervals.
 paths:
   /audit/events:
     get:
@@ -205,15 +205,15 @@ components:
           - Update
         assetId:
           type: string
-          description: A unique identifier for the Platform resource that the action
+          description: A unique identifier for the Experience Platform resource that the action
             was performed on.
         assetName:
           type: string
-          description: The name of the Platform resource that the action was performed
+          description: The name of the Experience Platform resource that the action was performed
             on.
         assetType:
           type: string
-          description: The type of Platform resource that the action was performed
+          description: The type of Experience Platform resource that the action was performed
             on.
           enum:
           - Class
@@ -298,7 +298,7 @@ components:
           example: yyyy-MM-dd'T'HH:mm:ss.SSSZ
         version:
           type: string
-          description: The version of the Platform resource that the action was performed
+          description: The version of the Experience Platform resource that the action was performed
             on.
     CollectionModel:
       title: CollectionModel


### PR DESCRIPTION
Internally tracked in PLAT-222696.

Updates were made to reflect that:

`/events` can return 1000 results from the past 90 days
`/export` can return 10,000 results from the past 360 days in 90 day intervals