### PR TITLE
PLAT-231118/custom-class-heading-typo

### DIFF
--- a/static/swagger-specs/schema-registry.yaml
+++ b/static/swagger-specs/schema-registry.yaml
@@ -1099,7 +1099,7 @@ paths:
     delete:
       tags:
       - "Data types"
-      summary: Delete a custom class
+      summary: Delete a custom data type
       description: >-
         Removing a data type is done through a DELETE request to the `$id` of the data type being removed.
         


### PR DESCRIPTION
Fixed a typo in an API call for custom classes.

Tracked internally in PLAT-231118.