### PR TITLE
PLAT-256785/Update-DULE-API-documentation---POST-Constraints-Endpoint-deprecated

### DIFF
--- a/static/swagger-specs/policy-service.yaml
+++ b/static/swagger-specs/policy-service.yaml
@@ -1155,6 +1155,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/CoreMarketingActionNotFound'
       x-codegen-request-body-name: body
+      deprecated: true
   /marketingActions/custom:
     get:
       tags:
@@ -1559,6 +1560,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       x-codegen-request-body-name: body
+      deprecated: true
   /bulk-eval:
     post:
       tags:

--- a/static/swagger-specs/policy-service.yaml
+++ b/static/swagger-specs/policy-service.yaml
@@ -1072,6 +1072,8 @@ paths:
       - Policy evaluation
       summary: Evaluate a core marketing action based on datasets and/or fields
       description: |-
+        >**IMPORTANT**: The `/constraints` endpoint for dataset-based evaluation is **deprecated**. To evaluate policy violation or perform multiple evaluation jobs, use the [bulk evaluation API (`/bulk-eval`)](https://experienceleague.adobe.com/en/docs/experience-platform/data-governance/api/evaluation#bulk) instead.
+
         This call returns a set of constraints that would govern an attempt to perform the given marketing action on an existing data source in Platform. The source data (typically a dataset) is specified by the `entityType` and `entityId` of the elements in the request body. In the case of a dataset entity, a set of fields may also be specified in the `entityMeta` to indicate that only those fields from that dataset should be used in the evaluation. The returned constraints take the form of a set of policies that would be violated by attempting the marketing action on the dataset(s) and/or field(s).
 
         You can also evaluate a marketing action based on a defined set of usage labels instead of testing against an actual data source. See the GET method for this endpoint for more information.
@@ -1473,6 +1475,8 @@ paths:
       - Policy evaluation
       summary: Evaluate a custom marketing action based on datasets and/or fields
       description: |-
+        >**IMPORTANT**: The `/constraints` endpoint for dataset-based evaluation is **deprecated**. To evaluate policy violation or perform multiple evaluation jobs, use the [bulk evaluation API (`/bulk-eval`)](https://experienceleague.adobe.com/en/docs/experience-platform/data-governance/api/evaluation#bulk) instead.
+
         This call returns a set of constraints that would govern an attempt to perform the given marketing action on an existing data source in Platform. The source data (typically a dataset) is specified by the "entityType" and "entityId" of the elements in the request body. In the case of a dataset entity, a set of fields may also be specified in the "entityMeta" to indicate that only those fields from that dataset should be used in the evaluation. The returned constraints take the form of a set of policies that would be violated by attempting the marketing action on the dataset(s) and/or field(s).
 
         You can also evaluate a marketing action based on a defined set of usage labels instead of testing against an actual data source. See the GET method for this endpoint for more information.


### PR DESCRIPTION
Update DULE API documentation - POST Constraints Endpoint deprecated

## Description

Deprecate the constraints API and point users to the bulk eval API that already exists in that document

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
